### PR TITLE
Add mypy config and extend dev extras

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
             "jupyter",
             "sphinx",
             "sphinx-rtd-theme",
+            "pandas-stubs",
+            "scipy-stubs",
         ],
         "tutorials": [
             "jupyter",


### PR DESCRIPTION
## Summary
- add `mypy.ini` enabling `ignore_missing_imports`
- install type stubs `pandas-stubs` and `scipy-stubs` via `extras_require['dev']`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688419c8d7a08323979d691dcbaa80ce