### PR TITLE
Fix extras for Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open("requirements.txt", "r", encoding="utf-8") as fh:
-    requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+    requirements = [
+        line.strip() for line in fh if line.strip() and not line.startswith("#")
+    ]
 
 setup(
     name="jump-diffusion-estimation",
@@ -48,8 +50,8 @@ setup(
             "jupyter",
             "sphinx",
             "sphinx-rtd-theme",
-            "pandas-stubs",
-            "scipy-stubs",
+            "pandas-stubs; python_version >= '3.10'",
+            "scipy-stubs; python_version >= '3.10'",
         ],
         "tutorials": [
             "jupyter",


### PR DESCRIPTION
## Summary
- avoid installing pandas-stubs and scipy-stubs on Python <3.10

## Testing
- `black setup.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68868d3e43ec8323a127b00f280b2856