### PR TITLE
Fix mypy errors

### DIFF
--- a/src/jump_diffusion/estimation/base_estimator.py
+++ b/src/jump_diffusion/estimation/base_estimator.py
@@ -26,7 +26,7 @@ class BaseEstimator(ABC):
         self.data = data
         self.dt = dt
         self.fitted = False
-        self.results = None
+        self.results: Optional[Dict[str, Any]] = None
 
     @abstractmethod
     def estimate(self, **kwargs) -> Dict[str, Any]:

--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -204,7 +204,7 @@ class JumpDiffusionEstimator(BaseEstimator):
         # Process results
         mu_hat, sigma_hat, p_hat, omega_hat, alpha_hat = result.x
 
-        self.results = {
+        results: Dict[str, Any] = {
             "parameters": {
                 "mu": mu_hat,
                 "sigma": sigma_hat,
@@ -226,12 +226,13 @@ class JumpDiffusionEstimator(BaseEstimator):
             },
         }
 
+        self.results = results
         self.fitted = True
-        return self.results
+        return results
 
     def diagnostics(self) -> None:
         """Print diagnostic information about the estimation."""
-        if not self.fitted:
+        if not self.fitted or self.results is None:
             print("Model not fitted. Run estimate() first.")
             return
 

--- a/src/jump_diffusion/simulation/jump_diffusion_simulator.py
+++ b/src/jump_diffusion/simulation/jump_diffusion_simulator.py
@@ -53,9 +53,9 @@ class JumpDiffusionSimulator(BaseSimulator):
         )
 
         # Store last simulation results
-        self.last_path = None
-        self.last_jumps = None
-        self.last_jump_times = None
+        self.last_path: Optional[np.ndarray] = None
+        self.last_jumps: Optional[np.ndarray] = None
+        self.last_jump_times: Optional[np.ndarray] = None
 
     def generate_jump_component(
         self, n_steps: int

--- a/src/jump_diffusion/validation/diagnostics.py
+++ b/src/jump_diffusion/validation/diagnostics.py
@@ -9,7 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # from typing import Dict, Any, Optional
-from typing import Dict
+from typing import Dict, List
 from scipy import stats
 
 
@@ -63,7 +63,7 @@ class ModelDiagnostics:
         n = len(residuals)
 
         # Calculate autocorrelations
-        autocorrs = []
+        autocorrs: List[float] = []
         for lag in range(1, lags + 1):
             if lag < n:
                 autocorr = np.corrcoef(residuals[:-lag], residuals[lag:])[0, 1]
@@ -72,9 +72,9 @@ class ModelDiagnostics:
                 autocorrs.append(0)
 
         # Ljung-Box statistic
-        autocorrs = np.array(autocorrs)
+        autocorr_array = np.array(autocorrs)
         denom = np.arange(n - 1, n - lags - 1, -1)
-        lb_stat = n * (n + 2) * np.sum(autocorrs**2 / denom)
+        lb_stat = n * (n + 2) * np.sum(autocorr_array**2 / denom)
 
         # Approximate p-value (chi-square distribution)
         p_value = 1 - stats.chi2.cdf(lb_stat, lags)

--- a/src/jump_diffusion/validation/monte_carlo.py
+++ b/src/jump_diffusion/validation/monte_carlo.py
@@ -8,7 +8,7 @@ controlled experiments with known parameters.
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from typing import Dict, Any
+from typing import Dict, Any, List
 from ..simulation import JumpDiffusionSimulator
 from ..estimation import JumpDiffusionEstimator
 
@@ -32,7 +32,7 @@ class ValidationExperiment:
             True parameter values to use for simulation
         """
         self.true_params = true_params
-        self.results = []
+        self.results: pd.DataFrame = pd.DataFrame()
         self.completed_experiments = 0
 
     def run_experiment(
@@ -70,7 +70,7 @@ class ValidationExperiment:
         # Create simulator
         simulator = JumpDiffusionSimulator(**self.true_params)
 
-        results = []
+        results: List[Dict[str, Any]] = []
         successful_runs = 0
 
         for i in range(n_simulations):


### PR DESCRIPTION
## Summary
- fix Ljung-Box test calculations and typing
- store simulation arrays in optional numpy fields
- type BaseEstimator results
- return typed results from maximum likelihood estimator
- type monte carlo validation results

## Testing
- `python -m mypy src/jump_diffusion`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886925f33ac8323812092d904bd763a