### PR TITLE
Fix typing compatibility with Python 3.8

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -10,7 +10,7 @@ import warnings
 from scipy import stats
 from scipy.stats import norm, skewnorm
 from scipy.optimize import minimize
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 from .base_estimator import BaseEstimator
 
 
@@ -152,7 +152,7 @@ class JumpDiffusionEstimator(BaseEstimator):
             initial_jump_skew,
         ]
 
-    def _get_parameter_bounds(self) -> List[tuple[Optional[float], Optional[float]]]:
+    def _get_parameter_bounds(self) -> List[Tuple[Optional[float], Optional[float]]]:
         """Get parameter bounds for optimization."""
         return [
             (None, None),  # mu


### PR DESCRIPTION
## Summary
- fix type hints in `JumpDiffusionEstimator` to avoid runtime errors on Python 3.8

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869aa3b7c48323a77896bfc4fd81dd