### PR TITLE
Fix Python 3.9 type hints

### DIFF
--- a/src/jump_diffusion/validation/diagnostics.py
+++ b/src/jump_diffusion/validation/diagnostics.py
@@ -9,7 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # from typing import Dict, Any, Optional
-from typing import Dict, List
+from typing import Dict, List, Union
 from scipy import stats
 
 
@@ -44,7 +44,7 @@ class ModelDiagnostics:
         self.dt = dt
         self.n_obs = len(self.data)
 
-    def ljung_box_test(self, lags: int = 10) -> Dict[str, float | int | bool]:
+    def ljung_box_test(self, lags: int = 10) -> Dict[str, Union[float, int, bool]]:
         """
         Ljung-Box test for autocorrelation in residuals.
 
@@ -86,7 +86,7 @@ class ModelDiagnostics:
             "reject_independence": p_value < 0.05,
         }
 
-    def normality_test(self) -> Dict[str, float | bool]:
+    def normality_test(self) -> Dict[str, Union[float, bool]]:
         """
         Test normality of standardized residuals.
 


### PR DESCRIPTION
## Summary
- support Python 3.9 by avoiding `|` union types in `ModelDiagnostics`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68869cae4b4883239d7c3d4956a39b44