### PR TITLE
Fix flake8 line lengths

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -152,7 +152,9 @@ class JumpDiffusionEstimator(BaseEstimator):
             initial_jump_skew,
         ]
 
-    def _get_parameter_bounds(self) -> List[Tuple[Optional[float], Optional[float]]]:
+    def _get_parameter_bounds(
+        self,
+    ) -> List[Tuple[Optional[float], Optional[float]]]:
         """Get parameter bounds for optimization."""
         return [
             (None, None),  # mu

--- a/src/jump_diffusion/validation/diagnostics.py
+++ b/src/jump_diffusion/validation/diagnostics.py
@@ -44,7 +44,9 @@ class ModelDiagnostics:
         self.dt = dt
         self.n_obs = len(self.data)
 
-    def ljung_box_test(self, lags: int = 10) -> Dict[str, Union[float, int, bool]]:
+    def ljung_box_test(
+        self, lags: int = 10
+    ) -> Dict[str, Union[float, int, bool]]:
         """
         Ljung-Box test for autocorrelation in residuals.
 


### PR DESCRIPTION
## Summary
- break long lines to satisfy flake8 E501
- run `flake8` and `pytest`

## Testing
- `flake8 src/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886bf561c808323b43e344a7052b3d9