### PR TITLE
Configure flake8 with Black's line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503


### PR DESCRIPTION
## Summary
- add `.flake8` in repo root for linting configuration

## Testing
- `flake8 --exit-zero`


------
https://chatgpt.com/codex/tasks/task_e_6886c7998a748323874d3642a9342c95