### PR TITLE
Fix initial guess creation in maximum likelihood

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -145,11 +145,13 @@ class JumpDiffusionEstimator(BaseEstimator):
         initial_jump_skew = float(np.sign(self.skewness)) * 2.0
 
         return np.array(
-            initial_mu,
-            initial_sigma,
-            initial_jump_prob,
-            initial_jump_scale,
-            initial_jump_skew,
+            [
+                initial_mu,
+                initial_sigma,
+                initial_jump_prob,
+                initial_jump_scale,
+                initial_jump_skew,
+            ]
         )
 
     def _get_parameter_bounds(


### PR DESCRIPTION
## Summary
- fix improper `np.array()` call when generating initial guess
- add the package to path via editable install for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c01a45ff483239e93debb10c0b5ed