### PR TITLE
Clarify monte_carlo plot_results usage

### DIFF
--- a/src/jump_diffusion/validation/monte_carlo.py
+++ b/src/jump_diffusion/validation/monte_carlo.py
@@ -194,8 +194,20 @@ class ValidationExperiment:
         return analysis
 
     def plot_results(self, figsize: tuple = (15, 10)):
-        """
-        Create comprehensive plots of validation results.
+        """Create plots summarizing parameter estimation accuracy.
+
+        Parameters
+        ----------
+        figsize : tuple, optional
+            Width and height of the Matplotlib figure in inches.
+
+        Notes
+        -----
+        Generates a 2x3 grid of subplots showing scatter plots for
+        each parameter and a summary bar chart of bias and RMSE. The
+        :meth:`run_experiment` method must be called beforehand to
+        populate ``self.results``. This function displays the plots
+        directly and returns ``None``.
         """
         if len(self.results) == 0:
             print("No results to plot. Run experiment first.")


### PR DESCRIPTION
## Summary
- Expand `plot_results` docstring with figure size, subplots description, and experiment prerequisites
- Note that `plot_results` shows figures directly and returns None

## Testing
- `pytest`
- `flake8 src/jump_diffusion/validation/monte_carlo.py`


------
https://chatgpt.com/codex/tasks/task_e_689d599787dc8323b43188367825941a