### PR TITLE
docs: document interactive notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Ready-to-run scripts are available in the `examples/` directory:
 
 - [basic_usage.py](examples/basic_usage.py) – demonstrates basic library usage
 - [validation_experiment.py](examples/validation_experiment.py) – runs Monte Carlo validation experiments
+- [jump_diffusion_playground.ipynb](notebooks/jump_diffusion_playground.ipynb) – interactive playground with sliders to explore simulation and estimation
+
+### Notebook setup
+
+Install optional dependencies and launch Jupyter to explore the notebook:
+
+```bash
+pip install ipywidgets matplotlib
+jupyter notebook
+```
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Ready-to-run scripts are available in the `examples/` directory:
 Install optional dependencies and launch Jupyter to explore the notebook:
 
 ```bash
-pip install ipywidgets matplotlib
+pip install notebook ipywidgets matplotlib
 jupyter notebook
 ```
 


### PR DESCRIPTION
## Summary
- Link the `jump_diffusion_playground.ipynb` interactive notebook in the examples section
- Add notebook setup instructions for installing optional dependencies and launching Jupyter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d62675fe48323b648fbd5b3912f7d