### PR TITLE
Add S&P 500 jump-diffusion example notebook

### DIFF
--- a/notebooks/sp500_jump_diffusion_example.ipynb
+++ b/notebooks/sp500_jump_diffusion_example.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0bade915",
+   "metadata": {},
+   "source": [
+    "# S&P 500 Jump-Diffusion Example\n",
+    "\n",
+    "This notebook downloads historical S&P 500 index data, preprocesses it by computing log returns, and fits a jump-diffusion model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad3b7306",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install yfinance -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb52bc43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yfinance as yf\n",
+    "import numpy as np\n",
+    "from jump_diffusion.estimation.maximum_likelihood import JumpDiffusionEstimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "422c9f96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download daily S&P 500 index data\n",
+    "data = yf.download('^GSPC', start='2015-01-01', end='2024-01-01', progress=False)\n",
+    "prices = data['Adj Close'].dropna()\n",
+    "prices.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88ee66cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preprocess: compute log returns and remove missing values\n",
+    "log_returns = np.diff(np.log(prices.values))\n",
+    "# Assume 252 trading days per year for daily data\n",
+    "dt = 1/252"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c317352",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fit the jump-diffusion model\n",
+    "estimator = JumpDiffusionEstimator(log_returns, dt)\n",
+    "results = estimator.estimate()\n",
+    "estimator.diagnostics()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook that downloads S&P 500 data and fits a jump-diffusion model

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d6af316388323842eecaa19e354ae