### PR TITLE
Consolidate duplicated math between models/, simulation/ and estimation/

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -1,17 +1,17 @@
 """
 Maximum Likelihood Estimator for Jump-Diffusion Models
 
-This module contains our original JumpDiffusionLikelihood class,
-refactored as JumpDiffusionEstimator to fit the new architecture.
+This module estimates JumpDiffusionModel parameters by maximizing the
+mixture likelihood implemented on the model itself.
 """
 
 import numpy as np
 import warnings
 from scipy import stats
-from scipy.stats import norm, skewnorm
 from scipy.optimize import minimize
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional
 from .base_estimator import BaseEstimator
+from ..models.jump_diffusion import JumpDiffusionModel
 
 
 class JumpDiffusionEstimator(BaseEstimator):
@@ -44,64 +44,15 @@ class JumpDiffusionEstimator(BaseEstimator):
 
         super().__init__(self.increments, dt)
 
+        # Model used to evaluate the mixture likelihood at trial parameters
+        self._model = JumpDiffusionModel()
+
         # Calculate basic statistics
         self.n_obs = len(self.increments)
         self.mean_increment = np.mean(self.increments)
         self.std_increment = np.std(self.increments)
         self.skewness = stats.skew(self.increments)
         self.kurtosis = stats.kurtosis(self.increments)
-
-    def _diffusion_density(
-        self,
-        x: np.ndarray,
-        mu: float,
-        sigma: float,
-    ) -> np.ndarray:
-        """Calculate pure diffusion density."""
-        mean = mu * self.dt
-        std = sigma * np.sqrt(self.dt)
-        return norm.pdf(x, loc=mean, scale=std)
-
-    def _jump_diffusion_density(
-        self,
-        x: np.ndarray,
-        mu: float,
-        sigma: float,
-        jump_scale: float,
-        jump_skew: float,
-    ) -> np.ndarray:
-        """Calculate jump + diffusion density."""
-        combined_mean = mu * self.dt
-        combined_var = sigma**2 * self.dt + jump_scale**2
-        combined_std = np.sqrt(combined_var)
-        adjusted_skew = jump_skew * jump_scale / combined_std
-
-        return skewnorm.pdf(
-            x,
-            a=adjusted_skew,
-            loc=combined_mean,
-            scale=combined_std,
-        )
-
-    def _mixture_density(
-        self,
-        x: np.ndarray,
-        mu: float,
-        sigma: float,
-        jump_prob: float,
-        jump_scale: float,
-        jump_skew: float,
-    ) -> np.ndarray:
-        """Calculate mixture density."""
-        diffusion_component = (1 - jump_prob) * self._diffusion_density(
-            x,
-            mu,
-            sigma,
-        )
-        jump_component = jump_prob * self._jump_diffusion_density(
-            x, mu, sigma, jump_scale, jump_skew
-        )
-        return diffusion_component + jump_component
 
     def log_likelihood(self, params: np.ndarray) -> float:
         """
@@ -125,16 +76,14 @@ class JumpDiffusionEstimator(BaseEstimator):
         if jump_prob < 0 or jump_prob > 1:
             return np.inf
 
-        # Calculate densities
-        densities = self._mixture_density(
-            self.increments, mu, sigma, jump_prob, jump_scale, jump_skew
+        self._model.update_parameters(
+            mu=mu,
+            sigma=sigma,
+            jump_prob=jump_prob,
+            jump_scale=jump_scale,
+            jump_skew=jump_skew,
         )
-
-        # Numerical stability
-        densities = np.maximum(densities, 1e-300)
-
-        # Return negative log-likelihood
-        return -np.sum(np.log(densities))
+        return -self._model.log_likelihood(self.increments, self.dt)
 
     def _get_initial_guess(self) -> np.ndarray:
         """Generate intelligent initial parameter guess."""
@@ -152,18 +101,6 @@ class JumpDiffusionEstimator(BaseEstimator):
                 initial_jump_scale,
                 initial_jump_skew,
             ]
-        )
-
-    def _get_parameter_bounds(
-        self,
-    ) -> Tuple[Tuple[Optional[float], Optional[float]], ...]:
-        """Get parameter bounds for optimization."""
-        return (
-            (-np.inf, np.inf),  # mu
-            (1e-6, np.inf),  # sigma > 0
-            (1e-6, 1 - 1e-6),  # 0 < jump_prob < 1
-            (1e-6, np.inf),  # jump_scale > 0
-            (-10, 10),  # jump_skew
         )
 
     def estimate(
@@ -193,7 +130,7 @@ class JumpDiffusionEstimator(BaseEstimator):
             initial_guess = self._get_initial_guess()
         initial_guess = np.asarray(initial_guess, dtype=float)
 
-        bounds = self._get_parameter_bounds()
+        bounds = self._model.get_parameter_bounds()
 
         # Optimization
         with warnings.catch_warnings():

--- a/src/jump_diffusion/simulation/jump_diffusion_simulator.py
+++ b/src/jump_diffusion/simulation/jump_diffusion_simulator.py
@@ -1,23 +1,24 @@
 """
 Jump-Diffusion Simulator Implementation
 
-This module contains our original JumpDiffusionSimulator class,
-refactored to fit the new architecture.
+This module contains JumpDiffusionSimulator, which builds on the path
+and likelihood math implemented in :class:`JumpDiffusionModel` and adds
+state-tracking and visualisation on top of it.
 """
 
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.stats import skewnorm
 from typing import Optional, Tuple
 from .base_simulator import BaseSimulator
+from ..models.jump_diffusion import JumpDiffusionModel
 
 
-class JumpDiffusionSimulator(BaseSimulator):
+class JumpDiffusionSimulator(BaseSimulator, JumpDiffusionModel):
     """
     Simulator for jump-diffusion processes with asymmetric jumps.
 
-    This is our original simulator, refactored to inherit from BaseSimulator
-    and integrate with the new modular architecture.
+    Inherits path generation from :class:`JumpDiffusionModel` and adds
+    state-tracking (for repeated plotting) and visualisation on top.
     """
 
     def __init__(
@@ -44,7 +45,8 @@ class JumpDiffusionSimulator(BaseSimulator):
         jump_skew : float
             Skewness parameter for jumps
         """
-        super().__init__(
+        JumpDiffusionModel.__init__(
+            self,
             mu=mu,
             sigma=sigma,
             jump_prob=jump_prob,
@@ -56,38 +58,6 @@ class JumpDiffusionSimulator(BaseSimulator):
         self.last_path: Optional[np.ndarray] = None
         self.last_jumps: Optional[np.ndarray] = None
         self.last_jump_times: Optional[np.ndarray] = None
-
-    def generate_jump_component(
-        self, n_steps: int
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """
-        Generate jump components for simulation.
-
-        Returns:
-        --------
-        tuple
-            (actual_jumps, jump_indicators, jump_times)
-        """
-        # Bernoulli process for jump timing
-        jump_indicators = np.random.binomial(
-            1,
-            self.parameters["jump_prob"],
-            n_steps,
-        )
-
-        # Jump magnitudes from skew-normal distribution
-        all_jump_sizes = skewnorm.rvs(
-            a=self.parameters["jump_skew"],
-            loc=0,
-            scale=self.parameters["jump_scale"],
-            size=n_steps,
-        )
-
-        # Actual jumps (zero when no jump occurs)
-        actual_jumps = jump_indicators * all_jump_sizes
-        jump_times = np.where(jump_indicators == 1)[0]
-
-        return actual_jumps, jump_indicators, jump_times
 
     def simulate_path(
         self,
@@ -115,31 +85,10 @@ class JumpDiffusionSimulator(BaseSimulator):
         tuple
             (times, path, jumps)
         """
-        if seed is not None:
-            np.random.seed(seed)
-
-        dt = T / n_steps
-        times = np.linspace(0, T, n_steps + 1)
-        path = np.zeros(n_steps + 1)
-        path[0] = x0
-
-        # Generate all random components
-        diffusion_innovations = np.random.normal(0, 1, n_steps)
-        (
-            jump_components,
-            jump_indicators,
-            jump_times,
-        ) = self.generate_jump_component(n_steps)
-
-        # Build path step by step
-        for i in range(n_steps):
-            drift_term = self.parameters["mu"] * dt
-            sigma_dt = self.parameters["sigma"] * np.sqrt(dt)
-            diffusion_term = sigma_dt * diffusion_innovations[i]
-            jump_term = jump_components[i]
-
-            increment = drift_term + diffusion_term + jump_term
-            path[i + 1] = path[i] + increment
+        times, path, jump_components = self.simulate(
+            T=T, n_steps=n_steps, x0=x0, seed=seed
+        )
+        jump_times = np.where(jump_components != 0)[0]
 
         # Store for plotting
         self.last_path = path


### PR DESCRIPTION
## Summary
- `JumpDiffusionModel` and `JumpDiffusionSimulator` each reimplemented the same path-generation loop (drift + diffusion + Bernoulli/skew-normal jumps). `JumpDiffusionSimulator` now inherits from `JumpDiffusionModel` and delegates `simulate_path()` to the inherited `simulate()`, keeping only its own state-tracking (`last_path`/`last_jumps`/`last_jump_times`) and plotting on top.
- `JumpDiffusionModel` and `JumpDiffusionEstimator` each reimplemented the same mixture-density/log-likelihood math. `JumpDiffusionEstimator` now composes a `JumpDiffusionModel` instance and delegates density/log-likelihood evaluation and parameter bounds to it.
- Fixes a latent sign-convention inconsistency: `JumpDiffusionModel.log_likelihood` returned the positive log-likelihood while the estimator's own copy returned the negative version for `minimize()` — the estimator now explicitly negates the model's value instead of maintaining a second formula that could silently drift out of sync.

## Test plan
- [x] `pytest tests/` — 10/10 passing
- [x] `flake8` clean on changed files
- [x] `mypy` clean on changed files
- [x] Manually verified simulator MRO/state (`isinstance(sim, JumpDiffusionModel)`, `last_jump_times`, `plot_simulation()`) and estimator likelihood sign convention (`-neg_ll == pos_ll`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)