### PR TITLE
Fix log-price/price scale bug in sp500_jump_diffusion_example.ipynb

### DIFF
--- a/notebooks/sp500_jump_diffusion_example.ipynb
+++ b/notebooks/sp500_jump_diffusion_example.ipynb
@@ -1,400 +1,357 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/jdospina/jump-diffusion-estimation/blob/main/notebooks/sp500_jump_diffusion_example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-RVX_Lt7dLnZ"
-      },
-      "source": [
-        "# 📈 Análisis del S&P 500 con un Modelo de Difusión con Saltos\n",
-        "\n",
-        "Este notebook es un tutorial completo sobre cómo aplicar un **modelo de difusión con saltos (jump-diffusion)** para analizar los rendimientos del índice S&P 500. Los mercados financieros a menudo exhiben movimientos bruscos (saltos) que no pueden ser capturados por modelos de difusión simples como el de Black-Scholes. Nuestro modelo busca capturar tanto la volatilidad continua como estos saltos abruptos.\n",
-        "\n",
-        "El flujo de trabajo será el siguiente:\n",
-        "1.  **Obtención y Preparación de Datos**: Descargaremos los datos históricos del S&P 500 (`^GSPC`) y calcularemos los rendimientos logarítmicos diarios.\n",
-        "2.  **Estimación de Parámetros**: Ajustaremos nuestro modelo de difusión con saltos a los datos históricos para estimar sus parámetros clave (`μ`, `σ`, probabilidad de salto, etc.).\n",
-        "3.  **Análisis de Resultados**: Interpretaremos los parámetros estimados y evaluaremos la calidad del ajuste del modelo.\n",
-        "4.  **Simulación y Comparación**: Usaremos los parámetros estimados para simular una nueva serie de rendimientos y compararemos su distribución con la de los datos reales para validar nuestro modelo."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "h7fJBwFYdLna"
-      },
-      "source": [
-        "## 1. Preparación del Entorno y Carga de Datos"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "exIPxDiudLna"
-      },
-      "outputs": [],
-      "source": [
-        "# Instalación de la librería jump-diffusion-estimation desde GitHub (última versión)\n",
-        "%pip install git+https://github.com/jdospina/jump-diffusion-estimation.git"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "XeO3LcwddLnb"
-      },
-      "outputs": [],
-      "source": [
-        "%pip install yfinance matplotlib seaborn -q"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2MRyrxrMdLnb"
-      },
-      "outputs": [],
-      "source": [
-        "import yfinance as yf\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import matplotlib.pyplot as plt\n",
-        "import seaborn as sns\n",
-        "from jump_diffusion.estimation import JumpDiffusionEstimator\n",
-        "from jump_diffusion.simulation import JumpDiffusionSimulator\n",
-        "\n",
-        "# Configuración de estilo para los gráficos\n",
-        "sns.set_style(\"whitegrid\")\n",
-        "plt.rcParams['figure.figsize'] = (12, 6)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NRA4VBWOdLnb"
-      },
-      "source": [
-        "### Descarga de Datos del S&P 500\n",
-        "Utilizaremos la librería `yfinance` para descargar los precios de cierre ajustados del índice S&P 500 (`^GSPC`) desde 2015 hasta principios de 2024."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "oXy96ve7dLnb"
-      },
-      "outputs": [],
-      "source": [
-        "data = yf.download('^GSPC', start='2015-01-01', end='2024-01-01', progress=False)\n",
-        "prices = data['Close']['^GSPC'].dropna()\n",
-        "\n",
-        "print(\"Primeros 5 precios del S&P 500:\")\n",
-        "print(prices.head())"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Veamos la serie original:"
-      ],
-      "metadata": {
-        "id": "WqM6TR1UgE3r"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "plt.figure(figsize=(14, 7))\n",
-        "plt.plot(prices.index, prices.values, alpha=0.8, color='b')\n",
-        "plt.title('Serie del valor de cierre del S&P 500')\n",
-        "plt.xlabel('Fecha')\n",
-        "plt.ylabel('Valor')\n",
-        "plt.grid(True)\n",
-        "plt.show()"
-      ],
-      "metadata": {
-        "id": "r_GPH2hRgGlo"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cdIHUoDndLnb"
-      },
-      "source": [
-        "### Cálculo de Rendimientos Logarítmicos\n",
-        "Los modelos financieros suelen trabajar con los **rendimientos logarítmicos** (`log(P_t) - log(P_{t-1})`), ya que tienen propiedades estadísticas más deseables (como la estacionariedad). Estos rendimientos representarán los \"incrementos\" en nuestro modelo."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zF0vhSVxdLnb"
-      },
-      "outputs": [],
-      "source": [
-        "log_returns = np.diff(np.log(prices.values))\n",
-        "\n",
-        "# El intervalo de tiempo (dt) es diario. Asumimos 252 días de trading al año.\n",
-        "dt = 1/252\n",
-        "\n",
-        "print(f\"Se han calculado {len(log_returns)} rendimientos logarítmicos diarios.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zVQ-z6KFdLnc"
-      },
-      "source": [
-        "### Visualización de los Rendimientos\n",
-        "Un primer vistazo a la serie de rendimientos nos permite observar la volatilidad y los picos extremos (posibles saltos), como los ocurridos durante la crisis de COVID-19 en 2020."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qHctM7VWdLnc"
-      },
-      "outputs": [],
-      "source": [
-        "plt.figure(figsize=(14, 7))\n",
-        "plt.plot(prices.index[1:], log_returns, alpha=0.8, color='b')\n",
-        "plt.title('Rendimientos Logarítmicos Diarios del S&P 500')\n",
-        "plt.xlabel('Fecha')\n",
-        "plt.ylabel('Log Return')\n",
-        "plt.grid(True)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Distribución de los incrementos"
-      ],
-      "metadata": {
-        "id": "WWCF6rkwhXPW"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "plt.figure(figsize=(14, 7))\n",
-        "plt.hist(log_returns, color='b', bins = 100)\n",
-        "plt.title('Rendimientos Logarítmicos Diarios del S&P 500')\n",
-        "plt.xlabel('Incrementos')\n",
-        "plt.ylabel('Frecuencia')\n",
-        "plt.grid(True)\n",
-        "plt.show()"
-      ],
-      "metadata": {
-        "id": "sXeBGfGQhZY7"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "C7t98Z20dLnc"
-      },
-      "source": [
-        "## 2. Estimación del Modelo de Difusión con Saltos"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QsfHdROWdLnc"
-      },
-      "outputs": [],
-      "source": [
-        "# Inicializamos el estimador con los rendimientos y el dt\n",
-        "estimator = JumpDiffusionEstimator(log_returns, dt)\n",
-        "\n",
-        "# Realizamos la estimación por máxima verosimilitud\n",
-        "results = estimator.estimate()\n",
-        "\n",
-        "# Mostramos un reporte de diagnóstico con los resultados\n",
-        "estimator.diagnostics()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YV9bHH0IdLnd"
-      },
-      "source": [
-        "## 3. Simulación y Comparación de Distribuciones\n",
-        "\n",
-        "Ahora, el paso crucial: ¿qué tan bien captura nuestro modelo la realidad? Para responder a esto, simularemos un proceso de difusión con saltos utilizando los parámetros que acabamos de estimar. Luego, compararemos la distribución de los rendimientos simulados con la distribución de los rendimientos reales del S&P 500."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1mWHGoawdLnd"
-      },
-      "outputs": [],
-      "source": [
-        "# Extraemos los parámetros estimados\n",
-        "estimated_params = results['parameters']\n",
-        "\n",
-        "# Creamos un simulador con estos parámetros\n",
-        "simulator = JumpDiffusionSimulator(**estimated_params)\n",
-        "\n",
-        "# Simulamos una trayectoria con la misma cantidad de pasos que los datos originales\n",
-        "T = len(log_returns) * dt\n",
-        "n_steps = len(log_returns)\n",
-        "\n",
-        "_, simulated_path, _ = simulator.simulate_path(T=T, n_steps=n_steps, x0=prices.iloc[0])\n",
-        "\n",
-        "# Calculamos los rendimientos logarítmicos de la simulación\n",
-        "simulated_log_returns = np.diff(np.log(simulated_path))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Veamos ahora el comportamiento de los datos simulados."
-      ],
-      "metadata": {
-        "id": "6TlRHss0fy4o"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "simulator.plot_simulation()"
-      ],
-      "metadata": {
-        "id": "TYytGTgWf2Aa"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "a939FC-xdLnd"
-      },
-      "source": [
-        "### Comparación Gráfica de las Distribuciones\n",
-        "\n",
-        "Visualizaremos ambas distribuciones (real y simulada) mediante histogramas y estimaciones de densidad kernel (KDE). Un buen ajuste se reflejará en una gran superposición entre ambas curvas."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "plt.figure(figsize=(14, 6))\n",
-        "\n",
-        "plt.subplot(1, 2, 1) # 1 row, 2 columns, 1st plot\n",
-        "plt.hist(log_returns, bins=100, alpha=0.8, color='royalblue')\n",
-        "plt.title('S&P 500 Log Returns (Real)')\n",
-        "plt.xlabel('Log Returns')\n",
-        "plt.ylabel('Frequency')\n",
-        "plt.grid(True)\n",
-        "\n",
-        "plt.subplot(1, 2, 2) # 1 row, 2 columns, 2nd plot\n",
-        "plt.hist(simulated_log_returns, bins=100, alpha=0.8, color='orangered')\n",
-        "plt.title('Simulated Log Returns')\n",
-        "plt.xlabel('Log Returns')\n",
-        "plt.ylabel('Frequency')\n",
-        "plt.grid(True)\n",
-        "\n",
-        "plt.tight_layout() # Adjust layout to prevent overlapping\n",
-        "plt.show()"
-      ],
-      "metadata": {
-        "id": "kXAsxTqpiO9b"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "fAmP8M3zdLnd"
-      },
-      "outputs": [],
-      "source": [
-        "plt.figure(figsize=(14, 8))\n",
-        "\n",
-        "# Histograma y KDE para los datos reales del S&P 500\n",
-        "sns.histplot(log_returns, bins=100, kde=True, stat='density', color='royalblue', label='S&P 500 (Real)')\n",
-        "\n",
-        "# Histograma y KDE para los datos simulados\n",
-        "sns.histplot(simulated_log_returns, bins=100, kde=True, stat='density', color='orangered', alpha=0.7, label='Simulado (con parámetros estimados)')\n",
-        "\n",
-        "plt.title('Comparación de la Distribución de Rendimientos: Real vs. Simulado', fontsize=16)\n",
-        "plt.xlabel('Rendimientos Logarítmicos', fontsize=12)\n",
-        "plt.ylabel('Densidad', fontsize=12)\n",
-        "plt.legend()\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tM_4P-NmdLnd"
-      },
-      "source": [
-        "### Conclusión\n",
-        "(En construcción, aún no se cumple)\n",
-        "\n",
-        "El gráfico de comparación muestra que la distribución de los rendimientos simulados se asemeja bastante a la de los datos reales. En particular, el modelo parece capturar bien:\n",
-        "\n",
-        "-   El **pico central** alrededor de cero, que representa los días de baja volatilidad.\n",
-        "-   Las **colas más pesadas** (leptocurtosis) que un modelo normal, indicando que los eventos extremos son más probables de lo que una distribución gaussiana sugeriría.\n",
-        "\n",
-        "Esto valida que el modelo de difusión con saltos es una herramienta significativamente mejor que un modelo de difusión simple para capturar la dinámica de los mercados financieros."
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.7"
-    },
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/jdospina/jump-diffusion-estimation/blob/main/notebooks/sp500_jump_diffusion_example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-RVX_Lt7dLnZ"
+   },
+   "source": [
+    "# 📈 Análisis del S&P 500 con un Modelo de Difusión con Saltos\n",
+    "\n",
+    "Este notebook es un tutorial completo sobre cómo aplicar un **modelo de difusión con saltos (jump-diffusion)** para analizar los rendimientos del índice S&P 500. Los mercados financieros a menudo exhiben movimientos bruscos (saltos) que no pueden ser capturados por modelos de difusión simples como el de Black-Scholes. Nuestro modelo busca capturar tanto la volatilidad continua como estos saltos abruptos.\n",
+    "\n",
+    "El flujo de trabajo será el siguiente:\n",
+    "1.  **Obtención y Preparación de Datos**: Descargaremos los datos históricos del S&P 500 (`^GSPC`) y calcularemos los rendimientos logarítmicos diarios.\n",
+    "2.  **Estimación de Parámetros**: Ajustaremos nuestro modelo de difusión con saltos a los datos históricos para estimar sus parámetros clave (`μ`, `σ`, probabilidad de salto, etc.).\n",
+    "3.  **Análisis de Resultados**: Interpretaremos los parámetros estimados y evaluaremos la calidad del ajuste del modelo.\n",
+    "4.  **Simulación y Comparación**: Usaremos los parámetros estimados para simular una nueva serie de rendimientos y compararemos su distribución con la de los datos reales para validar nuestro modelo."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h7fJBwFYdLna"
+   },
+   "source": [
+    "## 1. Preparación del Entorno y Carga de Datos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "exIPxDiudLna"
+   },
+   "outputs": [],
+   "source": "# Instalación de la librería jump-diffusion-estimation desde GitHub (última versión)\n%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "XeO3LcwddLnb"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install yfinance matplotlib seaborn -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2MRyrxrMdLnb"
+   },
+   "outputs": [],
+   "source": [
+    "import yfinance as yf\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from jump_diffusion.estimation import JumpDiffusionEstimator\n",
+    "from jump_diffusion.simulation import JumpDiffusionSimulator\n",
+    "\n",
+    "# Configuración de estilo para los gráficos\n",
+    "sns.set_style(\"whitegrid\")\n",
+    "plt.rcParams['figure.figsize'] = (12, 6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NRA4VBWOdLnb"
+   },
+   "source": [
+    "### Descarga de Datos del S&P 500\n",
+    "Utilizaremos la librería `yfinance` para descargar los precios de cierre ajustados del índice S&P 500 (`^GSPC`) desde 2015 hasta principios de 2024."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oXy96ve7dLnb"
+   },
+   "outputs": [],
+   "source": "data = yf.download('^GSPC', start='2015-01-01', end='2024-01-01', progress=False)\n\n# Según la versión de yfinance instalada, 'Close' puede venir como columna\n# MultiIndex (ticker, campo) o como una Serie plana. Manejamos ambos casos.\nclose = data['Close']\nprices = (close['^GSPC'] if isinstance(close, pd.DataFrame) else close).dropna()\n\nprint(\"Primeros 5 precios del S&P 500:\")\nprint(prices.head())"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Veamos la serie original:"
+   ],
+   "metadata": {
+    "id": "WqM6TR1UgE3r"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "plt.figure(figsize=(14, 7))\n",
+    "plt.plot(prices.index, prices.values, alpha=0.8, color='b')\n",
+    "plt.title('Serie del valor de cierre del S&P 500')\n",
+    "plt.xlabel('Fecha')\n",
+    "plt.ylabel('Valor')\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ],
+   "metadata": {
+    "id": "r_GPH2hRgGlo"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cdIHUoDndLnb"
+   },
+   "source": [
+    "### Cálculo de Rendimientos Logarítmicos\n",
+    "Los modelos financieros suelen trabajar con los **rendimientos logarítmicos** (`log(P_t) - log(P_{t-1})`), ya que tienen propiedades estadísticas más deseables (como la estacionariedad). Estos rendimientos representarán los \"incrementos\" en nuestro modelo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zF0vhSVxdLnb"
+   },
+   "outputs": [],
+   "source": [
+    "log_returns = np.diff(np.log(prices.values))\n",
+    "\n",
+    "# El intervalo de tiempo (dt) es diario. Asumimos 252 días de trading al año.\n",
+    "dt = 1/252\n",
+    "\n",
+    "print(f\"Se han calculado {len(log_returns)} rendimientos logarítmicos diarios.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zVQ-z6KFdLnc"
+   },
+   "source": [
+    "### Visualización de los Rendimientos\n",
+    "Un primer vistazo a la serie de rendimientos nos permite observar la volatilidad y los picos extremos (posibles saltos), como los ocurridos durante la crisis de COVID-19 en 2020."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qHctM7VWdLnc"
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(14, 7))\n",
+    "plt.plot(prices.index[1:], log_returns, alpha=0.8, color='b')\n",
+    "plt.title('Rendimientos Logarítmicos Diarios del S&P 500')\n",
+    "plt.xlabel('Fecha')\n",
+    "plt.ylabel('Log Return')\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Distribución de los incrementos"
+   ],
+   "metadata": {
+    "id": "WWCF6rkwhXPW"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "plt.figure(figsize=(14, 7))\n",
+    "plt.hist(log_returns, color='b', bins = 100)\n",
+    "plt.title('Rendimientos Logarítmicos Diarios del S&P 500')\n",
+    "plt.xlabel('Incrementos')\n",
+    "plt.ylabel('Frecuencia')\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ],
+   "metadata": {
+    "id": "sXeBGfGQhZY7"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "C7t98Z20dLnc"
+   },
+   "source": [
+    "## 2. Estimación del Modelo de Difusión con Saltos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QsfHdROWdLnc"
+   },
+   "outputs": [],
+   "source": "# Inicializamos el estimador con los rendimientos y el dt\nestimator = JumpDiffusionEstimator(log_returns, dt)\n\n# Realizamos la estimación por máxima verosimilitud\nresults = estimator.estimate()\n\nif not results['convergence']:\n    print(\"⚠️  El optimizador no convergió; los parámetros estimados podrían no ser confiables.\")\n\n# Mostramos un reporte de diagnóstico con los resultados\nestimator.diagnostics()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YV9bHH0IdLnd"
+   },
+   "source": [
+    "## 3. Simulación y Comparación de Distribuciones\n",
+    "\n",
+    "Ahora, el paso crucial: ¿qué tan bien captura nuestro modelo la realidad? Para responder a esto, simularemos un proceso de difusión con saltos utilizando los parámetros que acabamos de estimar. Luego, compararemos la distribución de los rendimientos simulados con la distribución de los rendimientos reales del S&P 500."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1mWHGoawdLnd"
+   },
+   "outputs": [],
+   "source": "# Extraemos los parámetros estimados\nestimated_params = results['parameters']\n\n# Creamos un simulador con estos parámetros\nsimulator = JumpDiffusionSimulator(**estimated_params)\n\n# Simulamos una trayectoria con la misma cantidad de pasos que los datos originales\nT = len(log_returns) * dt\nn_steps = len(log_returns)\n\n# El modelo se calibró sobre log-retornos, así que su variable de estado\n# representa log-precio: x0 debe ser log(P0), no el precio crudo.\n_, simulated_path, _ = simulator.simulate_path(\n    T=T, n_steps=n_steps, x0=np.log(prices.iloc[0]), seed=42\n)\n\n# simulated_path ya está en escala de log-precio, así que sus incrementos\n# son directamente los log-retornos simulados (sin aplicar np.log otra vez).\nsimulated_log_returns = np.diff(simulated_path)"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Veamos ahora el comportamiento de los datos simulados."
+   ],
+   "metadata": {
+    "id": "6TlRHss0fy4o"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "simulator.plot_simulation()"
+   ],
+   "metadata": {
+    "id": "TYytGTgWf2Aa"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a939FC-xdLnd"
+   },
+   "source": [
+    "### Comparación Gráfica de las Distribuciones\n",
+    "\n",
+    "Visualizaremos ambas distribuciones (real y simulada) mediante histogramas y estimaciones de densidad kernel (KDE). Un buen ajuste se reflejará en una gran superposición entre ambas curvas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "plt.figure(figsize=(14, 6))\n",
+    "\n",
+    "plt.subplot(1, 2, 1) # 1 row, 2 columns, 1st plot\n",
+    "plt.hist(log_returns, bins=100, alpha=0.8, color='royalblue')\n",
+    "plt.title('S&P 500 Log Returns (Real)')\n",
+    "plt.xlabel('Log Returns')\n",
+    "plt.ylabel('Frequency')\n",
+    "plt.grid(True)\n",
+    "\n",
+    "plt.subplot(1, 2, 2) # 1 row, 2 columns, 2nd plot\n",
+    "plt.hist(simulated_log_returns, bins=100, alpha=0.8, color='orangered')\n",
+    "plt.title('Simulated Log Returns')\n",
+    "plt.xlabel('Log Returns')\n",
+    "plt.ylabel('Frequency')\n",
+    "plt.grid(True)\n",
+    "\n",
+    "plt.tight_layout() # Adjust layout to prevent overlapping\n",
+    "plt.show()"
+   ],
+   "metadata": {
+    "id": "kXAsxTqpiO9b"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "fAmP8M3zdLnd"
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(14, 8))\n",
+    "\n",
+    "# Histograma y KDE para los datos reales del S&P 500\n",
+    "sns.histplot(log_returns, bins=100, kde=True, stat='density', color='royalblue', label='S&P 500 (Real)')\n",
+    "\n",
+    "# Histograma y KDE para los datos simulados\n",
+    "sns.histplot(simulated_log_returns, bins=100, kde=True, stat='density', color='orangered', alpha=0.7, label='Simulado (con parámetros estimados)')\n",
+    "\n",
+    "plt.title('Comparación de la Distribución de Rendimientos: Real vs. Simulado', fontsize=16)\n",
+    "plt.xlabel('Rendimientos Logarítmicos', fontsize=12)\n",
+    "plt.ylabel('Densidad', fontsize=12)\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tM_4P-NmdLnd"
+   },
+   "source": "### Conclusión\n\nEl gráfico de comparación muestra que la distribución de los rendimientos simulados se asemeja bastante a la de los datos reales. En particular, el modelo parece capturar bien:\n\n-   El **pico central** alrededor de cero, que representa los días de baja volatilidad.\n-   Las **colas más pesadas** (leptocurtosis) que un modelo normal, indicando que los eventos extremos son más probables de lo que una distribución gaussiana sugeriría.\n\nDicho esto, el S&P 500 real exhibe una curtosis todavía mayor que la del modelo: su pico central es más alto y angosto que el simulado, lo que sugiere que los datos reales concentran una proporción aún mayor de días de muy baja volatilidad de la que nuestra mezcla difusión + salto skew-normal logra reproducir. Esto es razonable — un solo régimen de saltos Bernoulli es una simplificación de la dinámica real, donde la volatilidad probablemente varía en el tiempo (clustering de volatilidad) en vez de ser constante entre saltos.\n\nCon todo, el ajuste general es sólido: el modelo de difusión con saltos captura tanto el pico central como las colas pesadas de forma sustancialmente mejor que un modelo de difusión simple (gaussiano), validándolo como una herramienta razonable para describir la dinámica de los rendimientos del S&P 500."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "colab": {
+   "provenance": [],
+   "include_colab_link": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
The notebook fits `JumpDiffusionEstimator` on log-returns, so the model's state variable represents log-price, not price. The simulation cell then seeded the simulator with the raw price level (`x0=prices.iloc[0]`) instead of `log(price)`, and took `np.log()` of the resulting path a second time when computing `simulated_log_returns`. This collapsed the simulated returns to roughly 1/4000th the scale of the real returns (verified numerically against synthetic data before fixing), making the real-vs-simulated comparison meaningless even though the notebook's conclusion claimed a good fit.

Fixes applied:
- `x0=np.log(prices.iloc[0])` instead of the raw price; drop the redundant `np.log()` when computing `simulated_log_returns`.
- `seed=42` added to `simulate_path` for reproducible comparisons across runs.
- Robust extraction of the `Close` column from `yfinance` (handles both MultiIndex and flat-column results, which vary by installed `yfinance` version).
- `-q` added to the package install cell, matching the fix already applied to `jump_diffusion_playground.ipynb` (#27).
- Warn if the MLE optimizer doesn't converge before using its parameters downstream.
- Conclusion cell rewritten now that it's been verified against real S&P 500 data by the repo owner: the real and simulated distributions overlap well, though the real series shows somewhat higher kurtosis than the fitted model reproduces.

## Test plan
- [x] Verified the scale bug numerically with synthetic data matching the notebook's exact steps (real σ ≈ 0.0126 vs. buggy simulated σ ≈ 0.000003 — ~4260x off; fixed version gives σ ≈ 0.0118, same order of magnitude)
- [x] Notebook executed end-to-end against live S&P 500 data by the repo owner — real vs. simulated distributions now overlap as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)