### PR TITLE
Add Kou double-exponential jump distribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,24 +87,24 @@ black src/ tests/
 ### Adding New Distributions
 1. Create a module in `distributions/` with a class inheriting from `JumpDistribution`
 2. Implement `pdf`, `default_params`, `param_bounds`, and `initial_guess`
-3. If a closed-form density is known for (diffusion + jump), override `diffusion_convolved_pdf`; otherwise the generic FFT-based convolution fallback handles it automatically (see `SGEDJump` for an example without a closed form, and `SkewNormalJump`/`NormalJump` for examples with one)
+3. If a closed-form density is known for (diffusion + jump), override `diffusion_convolved_pdf`; otherwise the generic FFT-based convolution fallback handles it automatically (see `SGEDJump` for an example without a closed form, and `SkewNormalJump`/`NormalJump`/`KouJump` for examples with one)
 4. If a fast native sampler exists, override `rvs`; otherwise the generic inverse-CDF fallback is used
-5. Export it from `distributions/__init__.py`
-6. Add tests: the pdf should integrate to 1, `diffusion_convolved_pdf` (if overridden) should match the generic FFT fallback within its numerical tolerance, and MLE should recover known parameters from simulated data
+5. If your parameters don't include a single `jump_scale` key (e.g. `KouJump`'s separate up/down scales), override `characteristic_scale` too — the FFT/inverse-CDF fallbacks use it to size their grids and silently return zeros without it
+6. Export it from `distributions/__init__.py`
+7. Add tests: the pdf should integrate to 1, `diffusion_convolved_pdf` (if overridden) should match the generic FFT fallback within its numerical tolerance, and MLE should recover known parameters from simulated data
 
 ## 🔬 Research Extensions
 
 We particularly welcome contributions in these areas:
 
 ### New Jump Distributions
-- Kou (double-exponential)
 - Student-t
 - Generalized hyperbolic distributions
 - Tempered stable distributions
 - Custom mixture distributions
 
-(Skew-normal, Normal/Merton, and the Skewed Generalized Error Distribution
-are already built in — see `distributions/`.)
+(Skew-normal, Normal/Merton, the Skewed Generalized Error Distribution, and
+Kou's double-exponential are already built in — see `distributions/`.)
 
 ### Advanced Models
 - Multiple jump types per period

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -68,13 +68,14 @@ a simulation-based Kolmogorov-Smirnov test:
 
 .. code-block:: python
 
-   from jump_diffusion.distributions import NormalJump, SGEDJump, SkewNormalJump
+   from jump_diffusion.distributions import KouJump, NormalJump, SGEDJump, SkewNormalJump
    from jump_diffusion.validation import JumpDistributionComparison
 
    comparison = JumpDistributionComparison(increments, dt)
    comparison.fit("Normal", NormalJump())
    comparison.fit("SkewNormal", SkewNormalJump())
    comparison.fit("SGED", SGEDJump())
+   comparison.fit("Kou", KouJump())
 
    print(comparison.compare())  # ranked by AIC, includes KS statistic/p-value
    comparison.plot_comparison()

--- a/src/jump_diffusion/distributions/__init__.py
+++ b/src/jump_diffusion/distributions/__init__.py
@@ -6,6 +6,7 @@ JumpDiffusionModel via its ``jump_distribution`` argument.
 """
 
 from .base import JumpDistribution
+from .kou import KouJump
 from .normal import NormalJump
 from .sged import SGEDJump
 from .skew_normal import SkewNormalJump
@@ -15,4 +16,5 @@ __all__ = [
     "SkewNormalJump",
     "NormalJump",
     "SGEDJump",
+    "KouJump",
 ]

--- a/src/jump_diffusion/distributions/base.py
+++ b/src/jump_diffusion/distributions/base.py
@@ -44,6 +44,18 @@ class JumpDistribution(ABC):
     ) -> Dict[str, float]:
         """Heuristic initial parameter guess derived from data moments."""
 
+    def characteristic_scale(self, params: Dict[str, float]) -> float:
+        """
+        Rough scale of the jump size, used to size the FFT/inverse-CDF grids
+        in :meth:`fft_convolved_pdf` and :meth:`rvs`.
+
+        Default reads ``jump_scale`` directly, the convention used by
+        ``NormalJump``/``SkewNormalJump``/``SGEDJump``. Override this for
+        distributions with a different parameterization (e.g. ``KouJump``,
+        which has separate up/down scales instead of a single one).
+        """
+        return params.get("jump_scale", 1.0)
+
     def diffusion_convolved_pdf(
         self,
         x: np.ndarray,
@@ -81,7 +93,7 @@ class JumpDistribution(ABC):
         evaluate at the requested points.
         """
         x = np.asarray(x, dtype=float)
-        jump_std = params.get("jump_scale")
+        jump_std = self.characteristic_scale(params)
         if jump_std is None or jump_std <= 0:
             return np.zeros_like(x)
 
@@ -127,7 +139,7 @@ class JumpDistribution(ABC):
         -- so that simulations stay reproducible. Pass an explicit
         ``np.random.Generator`` for an isolated, independent stream.
         """
-        jump_std = params.get("jump_scale", 1.0)
+        jump_std = self.characteristic_scale(params)
         h = jump_std / 200.0
         m = 2**12  # a coarser grid than fft_convolved_pdf suffices here
         k = np.arange(-m + 0.5, m, 1.0)

--- a/src/jump_diffusion/distributions/kou.py
+++ b/src/jump_diffusion/distributions/kou.py
@@ -1,0 +1,104 @@
+"""
+Kou (2002) asymmetric double-exponential jump distribution.
+
+Jump sizes are a mixture of one-sided exponentials: with probability
+``jump_prob_up`` the jump is positive with mean ``jump_scale_up``, otherwise
+it is negative with mean magnitude ``jump_scale_down``. Unlike the
+symmetric-around-zero ``NormalJump``/``SkewNormalJump`` parameterizations,
+this distribution has no separate loc/skew parameter -- asymmetry comes
+directly from ``jump_prob_up`` and the two scales differing.
+
+The convolution of a one-sided exponential with an independent normal is the
+well-known exponentially-modified-Gaussian ("ex-Gaussian") density, already
+implemented (numerically stably, via ``erfcx``) as ``scipy.stats.exponnorm``.
+Kou's double-exponential is just a ``jump_prob_up``-weighted mixture of two
+such terms (one direct, one reflected for the downward branch), so the
+closed-form diffusion-convolved density below reuses ``exponnorm`` rather
+than re-deriving/re-implementing the stability tricks by hand. Verified
+against direct numerical convolution in tests.
+"""
+
+from typing import Dict, Optional, Tuple, cast
+
+import numpy as np
+from scipy.stats import expon, exponnorm
+
+from .base import JumpDistribution
+
+
+class KouJump(JumpDistribution):
+    """Jump sizes distributed as Kou's asymmetric double exponential."""
+
+    param_names: Tuple[str, ...] = ("jump_prob_up", "jump_scale_up", "jump_scale_down")
+
+    def default_params(self) -> Dict[str, float]:
+        return {"jump_prob_up": 0.5, "jump_scale_up": 0.1, "jump_scale_down": 0.1}
+
+    def pdf(self, x: np.ndarray, params: Dict[str, float]) -> np.ndarray:
+        p = params["jump_prob_up"]
+        x = np.asarray(x, dtype=float)
+        up = p * expon.pdf(x, scale=params["jump_scale_up"])
+        down = (1 - p) * expon.pdf(-x, scale=params["jump_scale_down"])
+        return cast(np.ndarray, up + down)
+
+    def param_bounds(self) -> Dict[str, Tuple[Optional[float], Optional[float]]]:
+        return {
+            "jump_prob_up": (1e-6, 1 - 1e-6),
+            "jump_scale_up": (1e-6, None),
+            "jump_scale_down": (1e-6, None),
+        }
+
+    def characteristic_scale(self, params: Dict[str, float]) -> float:
+        return max(params["jump_scale_up"], params["jump_scale_down"])
+
+    def initial_guess(
+        self,
+        mean_increment: float,
+        std_increment: float,
+        skewness: float,
+    ) -> Dict[str, float]:
+        return {
+            "jump_prob_up": float(np.clip(0.5 + 0.1 * np.sign(skewness), 0.1, 0.9)),
+            "jump_scale_up": std_increment * 0.5,
+            "jump_scale_down": std_increment * 0.5,
+        }
+
+    def diffusion_convolved_pdf(
+        self,
+        x: np.ndarray,
+        params: Dict[str, float],
+        diffusion_mean: float,
+        diffusion_std: float,
+    ) -> Optional[np.ndarray]:
+        p = params["jump_prob_up"]
+        x = np.asarray(x, dtype=float)
+
+        up = p * exponnorm.pdf(
+            x,
+            K=params["jump_scale_up"] / diffusion_std,
+            loc=diffusion_mean,
+            scale=diffusion_std,
+        )
+        down = (1 - p) * exponnorm.pdf(
+            -x,
+            K=params["jump_scale_down"] / diffusion_std,
+            loc=-diffusion_mean,
+            scale=diffusion_std,
+        )
+        return cast(np.ndarray, up + down)
+
+    def rvs(
+        self,
+        params: Dict[str, float],
+        size: int,
+        random_state: Optional[np.random.Generator] = None,
+    ) -> np.ndarray:
+        rand = random_state if random_state is not None else np.random
+        is_up = rand.uniform(0.0, 1.0, size=size) < params["jump_prob_up"]
+        up = expon.rvs(
+            scale=params["jump_scale_up"], size=size, random_state=random_state
+        )
+        down = expon.rvs(
+            scale=params["jump_scale_down"], size=size, random_state=random_state
+        )
+        return cast(np.ndarray, np.where(is_up, up, -down))

--- a/tests/test_distributions/test_kou.py
+++ b/tests/test_distributions/test_kou.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for the Kou double-exponential jump distribution.
+"""
+
+import numpy as np
+import pytest
+from scipy.integrate import quad
+from scipy.stats import expon, norm
+
+from jump_diffusion.distributions import KouJump
+
+
+class TestKouJump:
+    """Test suite for KouJump."""
+
+    def test_pdf_matches_scipy_expon_pieces(self):
+        """The pdf should split into scaled one-sided exponentials."""
+        kj = KouJump()
+        params = {"jump_prob_up": 0.3, "jump_scale_up": 0.1, "jump_scale_down": 0.2}
+
+        x_up = np.linspace(0.001, 1, 11)
+        x_down = np.linspace(-1, -0.001, 11)
+
+        assert np.allclose(kj.pdf(x_up, params), 0.3 * expon.pdf(x_up, scale=0.1))
+        assert np.allclose(kj.pdf(x_down, params), 0.7 * expon.pdf(-x_down, scale=0.2))
+
+    def test_pdf_integrates_to_one(self):
+        kj = KouJump()
+        params = {"jump_prob_up": 0.35, "jump_scale_up": 0.12, "jump_scale_down": 0.09}
+        total, _ = quad(lambda j: kj.pdf(np.array([j]), params)[0], -5, 5, limit=1000)
+        assert total == pytest.approx(1.0, rel=1e-6)
+
+    def test_diffusion_convolved_pdf_matches_numerical_convolution(self):
+        """
+        The closed-form density of (diffusion + jump) must match direct
+        numerical integration of the convolution integral. This is the
+        real correctness check for the closed-form shortcut.
+        """
+        kj = KouJump()
+        params = {"jump_prob_up": 0.35, "jump_scale_up": 0.12, "jump_scale_down": 0.09}
+        diffusion_mean, diffusion_std = 0.05 / 252, 0.2 * np.sqrt(1 / 252)
+        x0 = 0.02
+
+        closed = kj.diffusion_convolved_pdf(
+            np.array([x0]), params, diffusion_mean, diffusion_std
+        )[0]
+
+        def integrand(j):
+            return (
+                norm.pdf(x0 - j, loc=diffusion_mean, scale=diffusion_std)
+                * kj.pdf(np.array([j]), params)[0]
+            )
+
+        true_value, _ = quad(integrand, -3, 3, limit=1000)
+
+        assert closed == pytest.approx(true_value, rel=1e-6)
+
+    def test_diffusion_convolved_pdf_matches_fft_fallback(self):
+        """
+        The closed form and the generic FFT-convolution fallback should
+        agree within the FFT's numerical approximation error.
+        """
+        kj = KouJump()
+        params = {"jump_prob_up": 0.35, "jump_scale_up": 0.12, "jump_scale_down": 0.09}
+        diffusion_mean, diffusion_std = 0.05 / 252, 0.2 * np.sqrt(1 / 252)
+        x = np.linspace(-0.05, 0.05, 21)
+
+        closed = kj.diffusion_convolved_pdf(x, params, diffusion_mean, diffusion_std)
+        fft = kj.fft_convolved_pdf(x, params, diffusion_mean, diffusion_std)
+
+        assert np.max(np.abs((closed - fft) / closed)) < 0.01
+
+    def test_rvs_recovers_moments(self):
+        """Simulated jump sizes should match the theoretical mean/std."""
+        kj = KouJump()
+        params = {"jump_prob_up": 0.3, "jump_scale_up": 0.2, "jump_scale_down": 0.1}
+        rng = np.random.default_rng(0)
+        samples = kj.rvs(params, size=200_000, random_state=rng)
+
+        p, su, sd = (
+            params["jump_prob_up"],
+            params["jump_scale_up"],
+            params["jump_scale_down"],
+        )
+        expected_mean = p * su - (1 - p) * sd
+        expected_var = p * 2 * su**2 + (1 - p) * 2 * sd**2 - expected_mean**2
+        expected_std = np.sqrt(expected_var)
+
+        assert np.isfinite(samples).all()
+        assert np.mean(samples) == pytest.approx(expected_mean, abs=0.01)
+        assert np.std(samples) == pytest.approx(expected_std, abs=0.01)
+
+    def test_rvs_all_positive_when_prob_up_is_one(self):
+        kj = KouJump()
+        params = {
+            "jump_prob_up": 1 - 1e-9,
+            "jump_scale_up": 0.1,
+            "jump_scale_down": 0.1,
+        }
+        rng = np.random.default_rng(1)
+        samples = kj.rvs(params, size=1000, random_state=rng)
+        assert np.all(samples > 0)


### PR DESCRIPTION
Reuses scipy.stats.exponnorm (ex-Gaussian) for a closed-form diffusion- convolved density, since Kou's jump is a probability-weighted mixture of two one-sided exponentials and exponnorm already handles the erfcx-based numerical stability for exponential+normal convolutions.

Also fixes a latent bug in the base JumpDistribution class: the generic FFT/inverse-CDF fallbacks hardcoded a "jump_scale" parameter key to size their grids, silently returning zeros for any distribution (like Kou) using a different parameterization. Introduces characteristic_scale() as an overridable extension point instead.