### PR TITLE
Add Student-t jump distribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,13 +98,13 @@ black src/ tests/
 We particularly welcome contributions in these areas:
 
 ### New Jump Distributions
-- Student-t
 - Generalized hyperbolic distributions
 - Tempered stable distributions
 - Custom mixture distributions
 
-(Skew-normal, Normal/Merton, the Skewed Generalized Error Distribution, and
-Kou's double-exponential are already built in — see `distributions/`.)
+(Skew-normal, Normal/Merton, the Skewed Generalized Error Distribution,
+Kou's double-exponential, and Student-t are already built in — see
+`distributions/`.)
 
 ### Advanced Models
 - Multiple jump types per period

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -68,7 +68,13 @@ a simulation-based Kolmogorov-Smirnov test:
 
 .. code-block:: python
 
-   from jump_diffusion.distributions import KouJump, NormalJump, SGEDJump, SkewNormalJump
+   from jump_diffusion.distributions import (
+       KouJump,
+       NormalJump,
+       SGEDJump,
+       SkewNormalJump,
+       StudentTJump,
+   )
    from jump_diffusion.validation import JumpDistributionComparison
 
    comparison = JumpDistributionComparison(increments, dt)
@@ -76,6 +82,7 @@ a simulation-based Kolmogorov-Smirnov test:
    comparison.fit("SkewNormal", SkewNormalJump())
    comparison.fit("SGED", SGEDJump())
    comparison.fit("Kou", KouJump())
+   comparison.fit("StudentT", StudentTJump())
 
    print(comparison.compare())  # ranked by AIC, includes KS statistic/p-value
    comparison.plot_comparison()

--- a/src/jump_diffusion/distributions/__init__.py
+++ b/src/jump_diffusion/distributions/__init__.py
@@ -10,6 +10,7 @@ from .kou import KouJump
 from .normal import NormalJump
 from .sged import SGEDJump
 from .skew_normal import SkewNormalJump
+from .student_t import StudentTJump
 
 __all__ = [
     "JumpDistribution",
@@ -17,4 +18,5 @@ __all__ = [
     "NormalJump",
     "SGEDJump",
     "KouJump",
+    "StudentTJump",
 ]

--- a/src/jump_diffusion/distributions/student_t.py
+++ b/src/jump_diffusion/distributions/student_t.py
@@ -1,0 +1,86 @@
+"""
+Student-t jump distribution.
+
+Location-scale Student-t, standardized so that ``jump_scale`` is the actual
+standard deviation of the jump (matching the convention used elsewhere in
+this package -- e.g. ``SGEDJump`` -- rather than scipy's raw ``t`` scale
+parameter, whose relationship to the standard deviation depends on the
+degrees of freedom). This is the same "standardized Student-t"
+parameterization used for Student-t innovations in GARCH-t models
+(Bollerslev, 1987): ``jump_df`` alone controls tail fatness, independent of
+overall spread.
+
+No closed form is known for the convolution of Student-t with an
+independent normal, so this distribution relies on the generic
+FFT-convolution and inverse-CDF fallbacks defined in ``JumpDistribution``.
+"""
+
+from typing import Dict, Optional, Tuple, cast
+
+import numpy as np
+from scipy.stats import t
+
+from .base import JumpDistribution
+
+
+def _scipy_scale(scale: float, df: float) -> float:
+    """Convert the standardized (std-dev) scale to scipy's raw ``t`` scale."""
+    return scale * np.sqrt((df - 2) / df)
+
+
+class StudentTJump(JumpDistribution):
+    """Jump sizes distributed as a (standardized) Student-t."""
+
+    param_names: Tuple[str, ...] = ("jump_loc", "jump_scale", "jump_df")
+
+    def default_params(self) -> Dict[str, float]:
+        return {"jump_loc": 0.0, "jump_scale": 0.15, "jump_df": 5.0}
+
+    def pdf(self, x: np.ndarray, params: Dict[str, float]) -> np.ndarray:
+        df = params["jump_df"]
+        return cast(
+            np.ndarray,
+            t.pdf(
+                x,
+                df=df,
+                loc=params["jump_loc"],
+                scale=_scipy_scale(params["jump_scale"], df),
+            ),
+        )
+
+    def param_bounds(self) -> Dict[str, Tuple[Optional[float], Optional[float]]]:
+        return {
+            "jump_loc": (None, None),
+            "jump_scale": (1e-6, None),
+            "jump_df": (2.05, 100.0),
+        }
+
+    def initial_guess(
+        self,
+        mean_increment: float,
+        std_increment: float,
+        skewness: float,
+    ) -> Dict[str, float]:
+        return {
+            "jump_loc": float(np.sign(skewness)) * std_increment * 0.1,
+            "jump_scale": std_increment * 0.5,
+            "jump_df": 5.0,
+        }
+
+    def rvs(
+        self,
+        params: Dict[str, float],
+        size: int,
+        random_state: Optional[np.random.Generator] = None,
+    ) -> np.ndarray:
+        df = params["jump_df"]
+        return cast(
+            np.ndarray,
+            t.rvs(
+                df=df,
+                loc=params["jump_loc"],
+                scale=_scipy_scale(params["jump_scale"], df),
+                size=size,
+                random_state=random_state,
+            ),
+        )

--- a/tests/test_distributions/test_student_t.py
+++ b/tests/test_distributions/test_student_t.py
@@ -1,0 +1,118 @@
+"""
+Unit tests for the Student-t jump distribution.
+"""
+
+import numpy as np
+import pytest
+from scipy.integrate import quad
+from scipy.stats import norm
+
+from jump_diffusion.distributions import StudentTJump
+from jump_diffusion.estimation import JumpDiffusionEstimator
+from jump_diffusion.simulation import JumpDiffusionSimulator
+
+
+class TestStudentTJump:
+    """Test suite for StudentTJump."""
+
+    def test_pdf_integrates_to_one(self):
+        st = StudentTJump()
+        params = {"jump_loc": 0.05, "jump_scale": 0.2, "jump_df": 4.0}
+        value, _ = quad(lambda x: st.pdf(np.array([x]), params)[0], -10, 10, limit=200)
+        assert value == pytest.approx(1.0, abs=1e-6)
+
+    def test_large_df_approaches_normal(self):
+        """As df -> infinity, the standardized Student-t -> normal(loc, scale)."""
+        st = StudentTJump()
+        params = {"jump_loc": 0.0, "jump_scale": 0.2, "jump_df": 5000.0}
+        x = np.linspace(-0.5, 0.5, 21)
+        assert np.allclose(
+            st.pdf(x, params), norm.pdf(x, loc=0.0, scale=0.2), atol=1e-3
+        )
+
+    def test_rvs_recovers_moments(self):
+        """jump_loc/jump_scale are E[X] and sqrt(Var[X]) by construction."""
+        st = StudentTJump()
+        params = {"jump_loc": 0.1, "jump_scale": 0.2, "jump_df": 5.0}
+        rng = np.random.default_rng(0)
+        samples = st.rvs(params, size=500_000, random_state=rng)
+
+        assert np.isfinite(samples).all()
+        assert np.mean(samples) == pytest.approx(0.1, abs=0.01)
+        assert np.std(samples) == pytest.approx(0.2, abs=0.01)
+
+    def test_fft_convolved_pdf_matches_numerical_convolution(self):
+        """
+        StudentTJump has no closed-form diffusion_convolved_pdf, so the
+        generic FFT fallback (inherited from JumpDistribution) is the only
+        available density -- verify it against direct numerical
+        integration of the convolution integral.
+        """
+        st = StudentTJump()
+        params = {"jump_loc": 0.0, "jump_scale": 0.15, "jump_df": 4.0}
+        diffusion_mean, diffusion_std = 0.05 / 252, 0.2 * np.sqrt(1 / 252)
+        x0 = 0.02
+
+        assert (
+            st.diffusion_convolved_pdf(
+                np.array([x0]), params, diffusion_mean, diffusion_std
+            )
+            is None
+        )
+
+        fft = st.fft_convolved_pdf(
+            np.array([x0]), params, diffusion_mean, diffusion_std
+        )[0]
+
+        def integrand(j):
+            return (
+                norm.pdf(x0 - j, loc=diffusion_mean, scale=diffusion_std)
+                * st.pdf(np.array([j]), params)[0]
+            )
+
+        true_value, _ = quad(integrand, -3, 3, limit=1000)
+
+        assert fft == pytest.approx(true_value, rel=1e-3)
+
+    def test_mle_recovers_known_parameters(self):
+        """
+        Simulate with known parameters and confirm MLE recovers them from a
+        nearby initial guess -- plain L-BFGS-B needs a reasonable starting
+        point for this mixture likelihood (see SGED's equivalent test).
+        """
+        true_params = {
+            "mu": 0.25,
+            "sigma": 0.5,
+            "jump_prob": 10 / 260,
+        }
+        true_jump_params = {
+            "jump_loc": 0.0,
+            "jump_scale": 0.2,
+            "jump_df": 4.0,
+        }
+
+        sim = JumpDiffusionSimulator(
+            jump_distribution=StudentTJump(), **true_params, **true_jump_params
+        )
+        times, path, _ = sim.simulate_path(T=5.0, n_steps=1300, x0=100.0, seed=123)
+        increments = np.diff(path)
+        dt = times[1] - times[0]
+
+        estimator = JumpDiffusionEstimator(
+            increments, dt, jump_distribution=StudentTJump()
+        )
+        initial_guess = np.array(
+            [
+                true_params["mu"],
+                true_params["sigma"],
+                true_params["jump_prob"],
+                true_jump_params["jump_loc"],
+                true_jump_params["jump_scale"],
+                true_jump_params["jump_df"],
+            ]
+        )
+        result = estimator.estimate(initial_guess=initial_guess)
+
+        assert result["convergence"]
+        assert result["parameters"]["sigma"] == pytest.approx(0.5, abs=0.05)
+        assert result["parameters"]["jump_scale"] == pytest.approx(0.2, abs=0.05)


### PR DESCRIPTION
## Summary
- Adds `StudentTJump` (location-scale Student-t) alongside the existing `NormalJump`/`SkewNormalJump`/`SGEDJump`/`KouJump`.
- Uses a **standardized** parameterization: `jump_scale` is the actual standard deviation of the jump (not scipy's raw `t` scale, which depends on `jump_df`), matching the `jump_scale` convention already established by `SGEDJump`/`NormalJump`/`SkewNormalJump`. This makes `jump_df` a pure tail-fatness knob independent of spread -- the same "standardized Student-t" convention used for Student-t innovations in GARCH-t models (Bollerslev, 1987).
- No closed form is known for Student-t convolved with a normal, so `diffusion_convolved_pdf` is left unimplemented and the generic FFT-convolution fallback (already in the base class) is used, same as `SGEDJump`. Verified against direct numerical integration (`quad`) in tests.
- Updates `CONTRIBUTING.md` (moves Student-t from "wanted" to "built-in") and `docs/quickstart.rst` (adds `StudentTJump` to the distribution-comparison example).

## Test plan
- [x] New `tests/test_distributions/test_student_t.py`: pdf integrates to 1, large-df limit matches the normal distribution, `rvs` recovers theoretical mean/std, FFT fallback matches numerical convolution (`quad`), and MLE recovers known simulated parameters (mirrors `SGEDJump`'s equivalent test).
- [x] Full suite: `pytest tests/` -- 37 passed.
- [x] `mypy src/jump_diffusion` -- no issues.
- [x] `black --check` / `flake8` -- clean.
- [x] Sphinx docs build (`sphinx -b html`) -- clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)