### PR TITLE
Add distribution comparison to S&P 500 notebook + Colab badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Ready-to-run scripts are available in the `examples/` directory:
 
 - [basic_usage.py](examples/basic_usage.py) – demonstrates basic library usage
 - [validation_experiment.py](examples/validation_experiment.py) – runs Monte Carlo validation experiments
-- [jump_diffusion_playground.ipynb](notebooks/jump_diffusion_playground.ipynb) – interactive playground with sliders to explore simulation and estimation
-- [sp500_jump_diffusion_example.ipynb](notebooks/sp500_jump_diffusion_example.ipynb) – applies the model to real S&P 500 data, from parameter estimation to comparing simulated vs. real return distributions
+- [jump_diffusion_playground.ipynb](notebooks/jump_diffusion_playground.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jdospina/jump-diffusion-estimation/blob/main/notebooks/jump_diffusion_playground.ipynb) – interactive playground: pick a jump distribution (Normal, Skew-Normal, SGED, Kou, Student-t), simulate, and try the "guess the parameters" game
+- [sp500_jump_diffusion_example.ipynb](notebooks/sp500_jump_diffusion_example.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jdospina/jump-diffusion-estimation/blob/main/notebooks/sp500_jump_diffusion_example.ipynb) – applies the model to real S&P 500 data: parameter estimation, simulated-vs-real comparison, and ranking all five jump distributions by AIC/BIC/KS
 
 ### Notebook setup
 

--- a/notebooks/sp500_jump_diffusion_example.ipynb
+++ b/notebooks/sp500_jump_diffusion_example.ipynb
@@ -2,9 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "5abdf422",
    "metadata": {
-    "id": "view-in-github",
-    "colab_type": "text"
+    "colab_type": "text",
+    "id": "view-in-github"
    },
    "source": [
     "<a href=\"https://colab.research.google.com/github/jdospina/jump-diffusion-estimation/blob/main/notebooks/sp500_jump_diffusion_example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -12,6 +13,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "97712b78",
    "metadata": {
     "id": "-RVX_Lt7dLnZ"
    },
@@ -24,11 +26,13 @@
     "1.  **Obtención y Preparación de Datos**: Descargaremos los datos históricos del S&P 500 (`^GSPC`) y calcularemos los rendimientos logarítmicos diarios.\n",
     "2.  **Estimación de Parámetros**: Ajustaremos nuestro modelo de difusión con saltos a los datos históricos para estimar sus parámetros clave (`μ`, `σ`, probabilidad de salto, etc.).\n",
     "3.  **Análisis de Resultados**: Interpretaremos los parámetros estimados y evaluaremos la calidad del ajuste del modelo.\n",
-    "4.  **Simulación y Comparación**: Usaremos los parámetros estimados para simular una nueva serie de rendimientos y compararemos su distribución con la de los datos reales para validar nuestro modelo."
+    "4.  **Simulación y Comparación**: Usaremos los parámetros estimados para simular una nueva serie de rendimientos y compararemos su distribución con la de los datos reales para validar nuestro modelo.\n",
+    "5.  **Comparación de distribuciones de salto**: probaremos las cinco distribuciones de salto disponibles en la librería (Normal, Skew-Normal, SGED, Kou, Student-t) y veremos cuál describe mejor los datos."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "29f1607f",
    "metadata": {
     "id": "h7fJBwFYdLna"
    },
@@ -39,15 +43,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "abfb5386",
    "metadata": {
     "id": "exIPxDiudLna"
    },
    "outputs": [],
-   "source": "# Instalación de la librería jump-diffusion-estimation desde GitHub (última versión)\n%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git"
+   "source": [
+    "# Instalación de la librería jump-diffusion-estimation desde GitHub (última versión)\n",
+    "%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a31d9775",
    "metadata": {
     "id": "XeO3LcwddLnb"
    },
@@ -59,6 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f23fd96a",
    "metadata": {
     "id": "2MRyrxrMdLnb"
    },
@@ -79,6 +89,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "63244c05",
    "metadata": {
     "id": "NRA4VBWOdLnb"
    },
@@ -90,40 +101,68 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "39ea1b29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🔧 Prueba cambiando esto -- otros tickers interesantes: 'AAPL', '^IXIC' (Nasdaq),\n",
+    "# 'BTC-USD', '^MXX' (IPC México), 'EURUSD=X', 'TSLA'...\n",
+    "TICKER = '^GSPC'\n",
+    "START = '2015-01-01'\n",
+    "END = '2024-01-01'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe3afd53",
    "metadata": {
     "id": "oXy96ve7dLnb"
    },
    "outputs": [],
-   "source": "data = yf.download('^GSPC', start='2015-01-01', end='2024-01-01', progress=False)\n\n# Según la versión de yfinance instalada, 'Close' puede venir como columna\n# MultiIndex (ticker, campo) o como una Serie plana. Manejamos ambos casos.\nclose = data['Close']\nprices = (close['^GSPC'] if isinstance(close, pd.DataFrame) else close).dropna()\n\nprint(\"Primeros 5 precios del S&P 500:\")\nprint(prices.head())"
+   "source": [
+    "data = yf.download(TICKER, start=START, end=END, progress=False)\n",
+    "\n",
+    "# Según la versión de yfinance instalada, 'Close' puede venir como columna\n",
+    "# MultiIndex (ticker, campo) o como una Serie plana. Manejamos ambos casos.\n",
+    "close = data['Close']\n",
+    "prices = (close[TICKER] if isinstance(close, pd.DataFrame) else close).dropna()\n",
+    "\n",
+    "print(f\"Primeros 5 precios de {TICKER}:\")\n",
+    "print(prices.head())"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Veamos la serie original:"
-   ],
+   "id": "90abca62",
    "metadata": {
     "id": "WqM6TR1UgE3r"
-   }
+   },
+   "source": [
+    "Veamos la serie original:"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "5f795b17",
+   "metadata": {
+    "id": "r_GPH2hRgGlo"
+   },
+   "outputs": [],
    "source": [
     "plt.figure(figsize=(14, 7))\n",
     "plt.plot(prices.index, prices.values, alpha=0.8, color='b')\n",
-    "plt.title('Serie del valor de cierre del S&P 500')\n",
+    "plt.title(f'Serie del valor de cierre de {TICKER}')\n",
     "plt.xlabel('Fecha')\n",
     "plt.ylabel('Valor')\n",
     "plt.grid(True)\n",
     "plt.show()"
-   ],
-   "metadata": {
-    "id": "r_GPH2hRgGlo"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6115e5f2",
    "metadata": {
     "id": "cdIHUoDndLnb"
    },
@@ -135,6 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "945625ce",
    "metadata": {
     "id": "zF0vhSVxdLnb"
    },
@@ -150,6 +190,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2920a40f",
    "metadata": {
     "id": "zVQ-z6KFdLnc"
    },
@@ -161,6 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "53bc8c2b",
    "metadata": {
     "id": "qHctM7VWdLnc"
    },
@@ -168,7 +210,7 @@
    "source": [
     "plt.figure(figsize=(14, 7))\n",
     "plt.plot(prices.index[1:], log_returns, alpha=0.8, color='b')\n",
-    "plt.title('Rendimientos Logarítmicos Diarios del S&P 500')\n",
+    "plt.title(f'Rendimientos Logarítmicos Diarios de {TICKER}')\n",
     "plt.xlabel('Fecha')\n",
     "plt.ylabel('Log Return')\n",
     "plt.grid(True)\n",
@@ -177,32 +219,35 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Distribución de los incrementos"
-   ],
+   "id": "ed2597cc",
    "metadata": {
     "id": "WWCF6rkwhXPW"
-   }
+   },
+   "source": [
+    "Distribución de los incrementos"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "4832e10b",
+   "metadata": {
+    "id": "sXeBGfGQhZY7"
+   },
+   "outputs": [],
    "source": [
     "plt.figure(figsize=(14, 7))\n",
     "plt.hist(log_returns, color='b', bins = 100)\n",
-    "plt.title('Rendimientos Logarítmicos Diarios del S&P 500')\n",
+    "plt.title(f'Rendimientos Logarítmicos Diarios de {TICKER}')\n",
     "plt.xlabel('Incrementos')\n",
     "plt.ylabel('Frecuencia')\n",
     "plt.grid(True)\n",
     "plt.show()"
-   ],
-   "metadata": {
-    "id": "sXeBGfGQhZY7"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "43eb8d98",
    "metadata": {
     "id": "C7t98Z20dLnc"
    },
@@ -213,14 +258,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7a6e7d15",
    "metadata": {
     "id": "QsfHdROWdLnc"
    },
    "outputs": [],
-   "source": "# Inicializamos el estimador con los rendimientos y el dt\nestimator = JumpDiffusionEstimator(log_returns, dt)\n\n# Realizamos la estimación por máxima verosimilitud\nresults = estimator.estimate()\n\nif not results['convergence']:\n    print(\"⚠️  El optimizador no convergió; los parámetros estimados podrían no ser confiables.\")\n\n# Mostramos un reporte de diagnóstico con los resultados\nestimator.diagnostics()"
+   "source": [
+    "# Inicializamos el estimador con los rendimientos y el dt\n",
+    "estimator = JumpDiffusionEstimator(log_returns, dt)\n",
+    "\n",
+    "# Realizamos la estimación por máxima verosimilitud\n",
+    "results = estimator.estimate()\n",
+    "\n",
+    "if not results['convergence']:\n",
+    "    print(\"⚠️  El optimizador no convergió; los parámetros estimados podrían no ser confiables.\")\n",
+    "\n",
+    "# Mostramos un reporte de diagnóstico con los resultados\n",
+    "estimator.diagnostics()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "169357dd",
    "metadata": {
     "id": "YV9bHH0IdLnd"
    },
@@ -233,34 +292,58 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1f7db4cf",
    "metadata": {
     "id": "1mWHGoawdLnd"
    },
    "outputs": [],
-   "source": "# Extraemos los parámetros estimados\nestimated_params = results['parameters']\n\n# Creamos un simulador con estos parámetros\nsimulator = JumpDiffusionSimulator(**estimated_params)\n\n# Simulamos una trayectoria con la misma cantidad de pasos que los datos originales\nT = len(log_returns) * dt\nn_steps = len(log_returns)\n\n# El modelo se calibró sobre log-retornos, así que su variable de estado\n# representa log-precio: x0 debe ser log(P0), no el precio crudo.\n_, simulated_path, _ = simulator.simulate_path(\n    T=T, n_steps=n_steps, x0=np.log(prices.iloc[0]), seed=42\n)\n\n# simulated_path ya está en escala de log-precio, así que sus incrementos\n# son directamente los log-retornos simulados (sin aplicar np.log otra vez).\nsimulated_log_returns = np.diff(simulated_path)"
+   "source": [
+    "# Extraemos los parámetros estimados\n",
+    "estimated_params = results['parameters']\n",
+    "\n",
+    "# Creamos un simulador con estos parámetros\n",
+    "simulator = JumpDiffusionSimulator(**estimated_params)\n",
+    "\n",
+    "# Simulamos una trayectoria con la misma cantidad de pasos que los datos originales\n",
+    "T = len(log_returns) * dt\n",
+    "n_steps = len(log_returns)\n",
+    "\n",
+    "# El modelo se calibró sobre log-retornos, así que su variable de estado\n",
+    "# representa log-precio: x0 debe ser log(P0), no el precio crudo.\n",
+    "_, simulated_path, _ = simulator.simulate_path(\n",
+    "    T=T, n_steps=n_steps, x0=np.log(prices.iloc[0]), seed=42\n",
+    ")\n",
+    "\n",
+    "# simulated_path ya está en escala de log-precio, así que sus incrementos\n",
+    "# son directamente los log-retornos simulados (sin aplicar np.log otra vez).\n",
+    "simulated_log_returns = np.diff(simulated_path)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Veamos ahora el comportamiento de los datos simulados."
-   ],
+   "id": "f2b952d9",
    "metadata": {
     "id": "6TlRHss0fy4o"
-   }
+   },
+   "source": [
+    "Veamos ahora el comportamiento de los datos simulados."
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "simulator.plot_simulation()"
-   ],
+   "execution_count": null,
+   "id": "d35a32e4",
    "metadata": {
     "id": "TYytGTgWf2Aa"
    },
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "simulator.plot_simulation()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d6dbea86",
    "metadata": {
     "id": "a939FC-xdLnd"
    },
@@ -272,12 +355,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "70c9b362",
+   "metadata": {
+    "id": "kXAsxTqpiO9b"
+   },
+   "outputs": [],
    "source": [
     "plt.figure(figsize=(14, 6))\n",
     "\n",
     "plt.subplot(1, 2, 1) # 1 row, 2 columns, 1st plot\n",
     "plt.hist(log_returns, bins=100, alpha=0.8, color='royalblue')\n",
-    "plt.title('S&P 500 Log Returns (Real)')\n",
+    "plt.title(f'{TICKER} Log Returns (Real)')\n",
     "plt.xlabel('Log Returns')\n",
     "plt.ylabel('Frequency')\n",
     "plt.grid(True)\n",
@@ -291,16 +380,12 @@
     "\n",
     "plt.tight_layout() # Adjust layout to prevent overlapping\n",
     "plt.show()"
-   ],
-   "metadata": {
-    "id": "kXAsxTqpiO9b"
-   },
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3d2a0caa",
    "metadata": {
     "id": "fAmP8M3zdLnd"
    },
@@ -309,7 +394,7 @@
     "plt.figure(figsize=(14, 8))\n",
     "\n",
     "# Histograma y KDE para los datos reales del S&P 500\n",
-    "sns.histplot(log_returns, bins=100, kde=True, stat='density', color='royalblue', label='S&P 500 (Real)')\n",
+    "sns.histplot(log_returns, bins=100, kde=True, stat='density', color='royalblue', label=f'{TICKER} (Real)')\n",
     "\n",
     "# Histograma y KDE para los datos simulados\n",
     "sns.histplot(simulated_log_returns, bins=100, kde=True, stat='density', color='orangered', alpha=0.7, label='Simulado (con parámetros estimados)')\n",
@@ -323,13 +408,99 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fca9bf3f",
    "metadata": {
     "id": "tM_4P-NmdLnd"
    },
-   "source": "### Conclusión\n\nEl gráfico de comparación muestra que la distribución de los rendimientos simulados se asemeja bastante a la de los datos reales. En particular, el modelo parece capturar bien:\n\n-   El **pico central** alrededor de cero, que representa los días de baja volatilidad.\n-   Las **colas más pesadas** (leptocurtosis) que un modelo normal, indicando que los eventos extremos son más probables de lo que una distribución gaussiana sugeriría.\n\nDicho esto, el S&P 500 real exhibe una curtosis todavía mayor que la del modelo: su pico central es más alto y angosto que el simulado, lo que sugiere que los datos reales concentran una proporción aún mayor de días de muy baja volatilidad de la que nuestra mezcla difusión + salto skew-normal logra reproducir. Esto es razonable — un solo régimen de saltos Bernoulli es una simplificación de la dinámica real, donde la volatilidad probablemente varía en el tiempo (clustering de volatilidad) en vez de ser constante entre saltos.\n\nCon todo, el ajuste general es sólido: el modelo de difusión con saltos captura tanto el pico central como las colas pesadas de forma sustancialmente mejor que un modelo de difusión simple (gaussiano), validándolo como una herramienta razonable para describir la dinámica de los rendimientos del S&P 500."
+   "source": [
+    "### Conclusión\n",
+    "\n",
+    "El gráfico de comparación muestra que la distribución de los rendimientos simulados se asemeja bastante a la de los datos reales. En particular, el modelo parece capturar bien:\n",
+    "\n",
+    "-   El **pico central** alrededor de cero, que representa los días de baja volatilidad.\n",
+    "-   Las **colas más pesadas** (leptocurtosis) que un modelo normal, indicando que los eventos extremos son más probables de lo que una distribución gaussiana sugeriría.\n",
+    "\n",
+    "Dicho esto, el S&P 500 real exhibe una curtosis todavía mayor que la del modelo: su pico central es más alto y angosto que el simulado, lo que sugiere que los datos reales concentran una proporción aún mayor de días de muy baja volatilidad de la que nuestra mezcla difusión + salto skew-normal logra reproducir. Esto es razonable — un solo régimen de saltos Bernoulli es una simplificación de la dinámica real, donde la volatilidad probablemente varía en el tiempo (clustering de volatilidad) en vez de ser constante entre saltos.\n",
+    "\n",
+    "Con todo, el ajuste general es sólido: el modelo de difusión con saltos captura tanto el pico central como las colas pesadas de forma sustancialmente mejor que un modelo de difusión simple (gaussiano), validándolo como una herramienta razonable para describir la dinámica de los rendimientos del S&P 500."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e87150e",
+   "metadata": {},
+   "source": [
+    "## 4. Comparando distribuciones de salto\n",
+    "\n",
+    "Hasta ahora usamos la distribución skew-normal por defecto. Pero la librería permite conectar distintas distribuciones de salto (`jump_distribution=`) sin cambiar nada más del flujo de estimación. Ajustemos las cinco disponibles a los mismos rendimientos y comparémoslas por AIC/BIC y una prueba de Kolmogorov-Smirnov basada en simulación, usando `JumpDistributionComparison`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6497e718",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jump_diffusion.distributions import (\n",
+    "    KouJump,\n",
+    "    NormalJump,\n",
+    "    SGEDJump,\n",
+    "    SkewNormalJump,\n",
+    "    StudentTJump,\n",
+    ")\n",
+    "from jump_diffusion.validation import JumpDistributionComparison\n",
+    "\n",
+    "comparison = JumpDistributionComparison(log_returns, dt)\n",
+    "comparison.fit(\"Normal\", NormalJump(), seed=42)\n",
+    "comparison.fit(\"SkewNormal\", SkewNormalJump(), seed=42)\n",
+    "comparison.fit(\"SGED\", SGEDJump(), seed=42)\n",
+    "comparison.fit(\"Kou\", KouJump(), seed=42)\n",
+    "comparison.fit(\"StudentT\", StudentTJump(), seed=42)\n",
+    "\n",
+    "comparison.compare()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0799757b",
+   "metadata": {},
+   "source": [
+    "En nuestra corrida de referencia (`^GSPC`, 2015-2024), el ranking por AIC fue:\n",
+    "\n",
+    "1. **Student-t** (AIC ≈ -14550) -- la mejor, y la única cuyo p-valor de KS (≈0.79) no rechaza que los rendimientos simulados provienen de la misma distribución que los reales.\n",
+    "2. **Kou** (AIC ≈ -14522), también razonable (p-valor KS ≈ 0.36).\n",
+    "3. **Skew-Normal** y **Normal**, muy por detrás, con p-valores de KS < 0.01 -- la prueba rechaza que capturen bien la distribución real.\n",
+    "4. **SGED** -- ⚠️ en esta corrida el optimizador (`L-BFGS-B`) **no convergió** desde su initial guess por defecto (`convergence: False`). Esto es una limitación conocida del optimizador frente a la verosimilitud de la mezcla SGED (el propio hallazgo aplicado de la tesis, comparando BFGS/L-BFGS-B contra Differential Evolution) -- no necesariamente una limitación de la distribución en sí. Es exactamente la motivación para agregar **Differential Evolution** como método de estimación alternativo (ver el roadmap del proyecto).\n",
+    "\n",
+    "Si cambias `TICKER` en la Sección 1 y vuelves a correr el notebook, ¡el ranking bien podría cambiar!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0df54614",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comparison.plot_comparison()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca7bd95e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "➡️ ¿Quieres jugar con estas mismas distribuciones de forma interactiva (sliders, simulación libre, y hasta un juego de adivinar parámetros)? Prueba [`jump_diffusion_playground.ipynb`](https://colab.research.google.com/github/jdospina/jump-diffusion-estimation/blob/main/notebooks/jump_diffusion_playground.ipynb) (abre en Colab)."
+   ]
   }
  ],
  "metadata": {
+  "colab": {
+   "include_colab_link": true,
+   "provenance": []
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -346,12 +517,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.7"
-  },
-  "colab": {
-   "provenance": [],
-   "include_colab_link": true
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- `sp500_jump_diffusion_example.ipynb` predates Kou/SGED/Student-t (PRs #29-#35) and only ever used the default skew-normal jump distribution. Adds a new **"4. Comparando distribuciones de salto"** section that fits all five distributions via `JumpDistributionComparison` and ranks them by AIC/BIC + a simulation-based KS test (mirrors the `docs/quickstart.rst` snippet, but on real data).
- Verified against a live run on `^GSPC` (2015-2024): **Student-t wins** (best AIC, the only KS test that doesn't reject the fit), **Kou** is a close second, **Normal/Skew-Normal** lag with KS p<0.01, and **SGED's default L-BFGS-B initial guess doesn't converge** on this dataset -- called out explicitly in the notebook as a known optimizer-robustness issue (not a distributional one), tying into the project's Differential Evolution roadmap item.
- Parametrizes `TICKER`/`START`/`END` (previously hardcoded to `'^GSPC'`) as a clearly-marked, easy-to-edit cell, with plot titles updated to reflect the chosen ticker.
- Adds a closing cross-link to the playground notebook (PR #36).
- **README.md**: adds an "Open in Colab" badge next to *both* notebook bullets -- previously only the sp500 notebook had one, and only inside the notebook file itself (invisible when just browsing the README on GitHub).

## Test plan
- [x] Full suite: `pytest tests/` -- 37 passed (no library code changed in this PR). `mypy` / `black --check` / `flake8` -- clean.
- [x] Notebook validated with `nbformat.validate()`.
- [x] Executed the notebook headlessly end-to-end (`jupyter nbconvert --to notebook --execute`) in an isolated scratch venv, including the live `yfinance` download and all five distribution fits -- no errors; the comparison table's numbers match exactly what's quoted in the notebook's interpretation markdown.
- [ ] **Cannot verify actual Colab rendering from this environment** (no network access to colab.research.google.com) -- please click through the Colab badge once to confirm it opens and runs as expected in the real Colab frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)