### PR TITLE
Fix diagnostics() KeyError when fitted with KouJump

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -213,12 +213,14 @@ class JumpDiffusionEstimator(BaseEstimator):
         print("\nDATA vs MODEL COMPARISON")
         print("-" * 30)
         theoretical_mean = params["mu"] * self.dt
-        # Approximation: treats jump_scale as the jump size's standard
-        # deviation, which holds exactly for the Normal jump distribution
-        # and approximately for the others.
+        # Approximation: treats the distribution's characteristic scale as
+        # the jump size's standard deviation, which holds exactly for the
+        # Normal jump distribution and approximately for the others.
+        jump_scale = self._model.jump_distribution.characteristic_scale(
+            {k: params[k] for k in self._model.jump_distribution.param_names}
+        )
         theoretical_var = (
-            params["sigma"] ** 2 * self.dt
-            + params["jump_prob"] * params["jump_scale"] ** 2
+            params["sigma"] ** 2 * self.dt + params["jump_prob"] * jump_scale**2
         )
 
         print("Mean increment:")

--- a/tests/test_estimation/test_maximum_likelihood.py
+++ b/tests/test_estimation/test_maximum_likelihood.py
@@ -3,6 +3,7 @@ Unit tests for maximum likelihood estimation.
 """
 
 import numpy as np
+from jump_diffusion.distributions import KouJump
 from jump_diffusion.estimation import JumpDiffusionEstimator
 from jump_diffusion.simulation import JumpDiffusionSimulator
 
@@ -55,6 +56,20 @@ class TestJumpDiffusionEstimator:
         self.estimator.estimate()
         # This should not raise an exception
         self.estimator.diagnostics()
+
+    def test_diagnostics_with_kou_jump(self):
+        """diagnostics() must not assume a ``jump_scale`` parameter.
+
+        Regression test: KouJump parameterizes jumps as
+        (jump_prob_up, jump_scale_up, jump_scale_down), so diagnostics()
+        used to raise KeyError('jump_scale') after fitting with it.
+        """
+        estimator = JumpDiffusionEstimator(
+            self.increments, self.dt, jump_distribution=KouJump()
+        )
+        estimator.estimate()
+        # This should not raise an exception
+        estimator.diagnostics()
 
     def test_estimation_on_simulated_path(self):
         """Estimate parameters from a simulated jump-diffusion path."""


### PR DESCRIPTION
## Summary
- `JumpDiffusionEstimator.diagnostics()` hardcoded `params["jump_scale"]` when computing the theoretical variance, so calling it after fitting with `jump_distribution=KouJump()` raised `KeyError` (Kou uses `jump_prob_up`/`jump_scale_up`/`jump_scale_down` instead).
- Replaced the hardcoded key with the distribution's `characteristic_scale()` method, which `JumpDistribution` defines exactly for this purpose (default reads `jump_scale`; `KouJump` overrides it with `max(jump_scale_up, jump_scale_down)`).
- Added a regression test that fits a `KouJump` estimator on a short simulated series and calls `diagnostics()`; it fails with `KeyError: 'jump_scale'` before this fix.

## Test plan
- [x] `pytest` — 41 passed (includes new `test_diagnostics_with_kou_jump`)
- [x] `mypy src` — no issues
- [x] `black --check src tests` — clean
- [x] `flake8 src tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)