### PR TITLE
fix: Prevent duplicate plot rendering in plot_simulation

### DIFF
--- a/src/jump_diffusion/simulation/jump_diffusion_simulator.py
+++ b/src/jump_diffusion/simulation/jump_diffusion_simulator.py
@@ -256,6 +256,5 @@ class JumpDiffusionSimulator(BaseSimulator, JumpDiffusionModel):
         axes[1, 1].grid(True, alpha=0.3)
 
         plt.tight_layout()
-        plt.show()
-
+        
         return fig


### PR DESCRIPTION
Removes plt.show() in JumpDiffusionSimulator.plot_simulation() to fix a bug where Jupyter notebooks render the figure twice (once due to show() and once by returning the figure object), causing a visual 4x2 grid instead of a 2x2 grid.