### PR TITLE
fix: Prevent N/A standard errors on steep log-likelihoods

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -421,12 +421,14 @@ class JumpDiffusionEstimator(BaseEstimator):
 
             if len(profile_valid) >= 3:
                 # Fit parabola: y = a*x^2 + b*x + c
-                fit_mask = profile_valid >= (opt_log_lik - 5.0)
-                if np.sum(fit_mask) >= 3:
-                    p_coefs = np.polyfit(grid_valid[fit_mask], profile_valid[fit_mask], 2)
-                    a = p_coefs[0]
-                    if a < 0:
-                        se_val = np.sqrt(-1.0 / (2.0 * a))
+                # Use up to 5 points with the highest log-likelihood to ensure we are near the peak
+                # and avoid arbitrary absolute log-likelihood thresholds.
+                n_fit_points = min(5, len(profile_valid))
+                top_indices = np.argsort(profile_valid)[-n_fit_points:]
+                p_coefs = np.polyfit(grid_valid[top_indices], profile_valid[top_indices], 2)
+                a = p_coefs[0]
+                if a < 0:
+                    se_val = np.sqrt(-1.0 / (2.0 * a))
 
                 # Find roots where L_p(x) == threshold using linear interpolation
                 left_mask = grid_valid <= mle_val


### PR DESCRIPTION
Replaces the absolute '-5.0' log-likelihood threshold for filtering points in the parabolic fit with a dynamic selection of the top 5 points. This fixes an issue where very sharp log-likelihood peaks (common in large datasets like S&P 500) resulted in less than 3 points meeting the threshold, causing the Standard Error to be reported as N/A.