### PR TITLE
chore: Fix CI by applying black and resolving flake8 violations

### DIFF
--- a/src/jump_diffusion/distributions/normal.py
+++ b/src/jump_diffusion/distributions/normal.py
@@ -18,9 +18,9 @@ from .base import JumpDistribution
 class NormalJump(JumpDistribution):
     """
     Jump sizes distributed as a normal centered at zero.
-    
+
     References:
-    - Merton, R. C. (1976). Option pricing when underlying stock returns 
+    - Merton, R. C. (1976). Option pricing when underlying stock returns
       are discontinuous. Journal of financial economics, 3(1-2), 125-144.
     """
 

--- a/src/jump_diffusion/distributions/sged.py
+++ b/src/jump_diffusion/distributions/sged.py
@@ -65,11 +65,12 @@ def _standardized_sged_pdf(z: np.ndarray, nu: float, xi: float) -> np.ndarray:
 class SGEDJump(JumpDistribution):
     """
     Jump sizes distributed as a Skewed Generalized Error Distribution.
-    
+
     References:
     - Ospina Arango, J. D. (2009). Tesis de Maestría. Universidad Nacional de Colombia.
-    - Theodossiou, P. (2015). Skewed Generalized Error Distribution of 
-      Financial Assets and Option Pricing. Multinational Finance Journal, 19(4), 223-266.
+    - Theodossiou, P. (2015). Skewed Generalized Error Distribution of
+      Financial Assets and Option Pricing. Multinational Finance Journal,
+      19(4), 223-266.
     """
 
     param_names: Tuple[str, ...] = ("jump_loc", "jump_scale", "jump_nu", "jump_xi")

--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -25,7 +25,7 @@ class JumpDiffusionEstimator(BaseEstimator):
     array of increments.
 
     References:
-    - Ardia, D., Ospina, J. D., & Giraldo, N. D. (2011). Jump-diffusion 
+    - Ardia, D., Ospina, J. D., & Giraldo, N. D. (2011). Jump-diffusion
       calibration using differential evolution. Wilmott, 2011(55), 76-79.
     """
 
@@ -342,7 +342,8 @@ class JumpDiffusionEstimator(BaseEstimator):
         confidence_intervals = {}
         profile_data = {}
 
-        # Critical chi-squared value for the profile likelihood threshold (Wilks' theorem)
+        # Critical chi-squared value for the profile likelihood threshold
+        # (Wilks' theorem)
         critical_val = stats.chi2.ppf(confidence_level, df=1)
         threshold = opt_log_lik - 0.5 * critical_val
 
@@ -355,7 +356,7 @@ class JumpDiffusionEstimator(BaseEstimator):
             # Initialize profile dictionary with MLE
             profile_dict = {mle_val: opt_log_lik}
             low_bound, high_bound = bounds[idx]
-            
+
             # Optimization closure
             def optimize_profile(val):
                 def neg_log_lik_profile(free_params):
@@ -367,9 +368,13 @@ class JumpDiffusionEstimator(BaseEstimator):
                             full_params[j] = free_params[free_idx]
                             free_idx += 1
                     return self.log_likelihood(full_params)
-                
-                free_init = [opt_param_vals[j] for j in range(len(self._param_names)) if j != idx]
-                free_bounds = [bounds[j] for j in range(len(self._param_names)) if j != idx]
+
+                free_init = [
+                    opt_param_vals[j] for j in range(len(self._param_names)) if j != idx
+                ]
+                free_bounds = [
+                    bounds[j] for j in range(len(self._param_names)) if j != idx
+                ]
 
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
@@ -389,7 +394,7 @@ class JumpDiffusionEstimator(BaseEstimator):
             initial_step = max(0.01 * abs(mle_val), 1e-4)
             max_step_factor = 2.0
             max_search_steps = 15
-            
+
             # Outward search right
             curr_val = mle_val
             step = initial_step
@@ -402,13 +407,13 @@ class JumpDiffusionEstimator(BaseEstimator):
                     break
                 val_lik = optimize_profile(next_val)
                 profile_dict[next_val] = val_lik
-                
+
                 if val_lik < threshold:
                     break
-                
+
                 curr_val = next_val
                 step *= max_step_factor
-                
+
             # Outward search left
             curr_val = mle_val
             step = initial_step
@@ -421,45 +426,45 @@ class JumpDiffusionEstimator(BaseEstimator):
                     break
                 val_lik = optimize_profile(next_val)
                 profile_dict[next_val] = val_lik
-                
+
                 if val_lik < threshold:
                     break
-                
+
                 curr_val = next_val
                 step *= max_step_factor
 
             # Sort evaluated points
             sorted_vals = sorted(list(profile_dict.keys()))
-            
+
             # Infill points if we have fewer than n_points
             while len(sorted_vals) < n_points:
                 # Find the gap with the largest absolute distance
                 max_gap_idx = -1
                 max_gap_dist = -1
                 for i in range(len(sorted_vals) - 1):
-                    v1, v2 = sorted_vals[i], sorted_vals[i+1]
+                    v1, v2 = sorted_vals[i], sorted_vals[i + 1]
                     dist = v2 - v1
                     if dist > max_gap_dist:
                         max_gap_dist = dist
                         max_gap_idx = i
-                        
+
                 if max_gap_idx == -1:
                     break
-                
+
                 v1 = sorted_vals[max_gap_idx]
                 v2 = sorted_vals[max_gap_idx + 1]
                 mid_val = (v1 + v2) / 2.0
                 val_lik = optimize_profile(mid_val)
                 profile_dict[mid_val] = val_lik
                 sorted_vals = sorted(list(profile_dict.keys()))
-                
+
             grid = np.array(sorted_vals)
             profile_vals = np.array([profile_dict[v] for v in grid])
 
             valid_mask = np.isfinite(profile_vals)
             grid_valid = grid[valid_mask]
             profile_valid = profile_vals[valid_mask]
-            
+
             if len(grid_valid) > 0:
                 min_val = grid_valid.min()
                 max_val = grid_valid.max()
@@ -472,11 +477,14 @@ class JumpDiffusionEstimator(BaseEstimator):
 
             if len(profile_valid) >= 3:
                 # Fit parabola: y = a*x^2 + b*x + c
-                # Use up to 5 points with the highest log-likelihood to ensure we are near the peak
-                # and avoid arbitrary absolute log-likelihood thresholds.
+                # Use up to 5 points with the highest log-likelihood to ensure
+                # we are near the peak and avoid arbitrary absolute
+                # log-likelihood thresholds.
                 n_fit_points = min(5, len(profile_valid))
                 top_indices = np.argsort(profile_valid)[-n_fit_points:]
-                p_coefs = np.polyfit(grid_valid[top_indices], profile_valid[top_indices], 2)
+                p_coefs = np.polyfit(
+                    grid_valid[top_indices], profile_valid[top_indices], 2
+                )
                 a = p_coefs[0]
                 if a < 0:
                     se_val = np.sqrt(-1.0 / (2.0 * a))
@@ -494,15 +502,22 @@ class JumpDiffusionEstimator(BaseEstimator):
                 grid_right = grid_valid[right_mask]
                 prof_right = profile_valid[right_mask]
                 if len(prof_right) >= 2 and prof_right[-1] < threshold:
-                    ci_high = float(np.interp(threshold, prof_right[::-1], grid_right[::-1]))
+                    ci_high = float(
+                        np.interp(threshold, prof_right[::-1], grid_right[::-1])
+                    )
                 else:
                     ci_high = float(max_val)
-                    
+
                 # Fallback: If parabolic fit failed (a >= 0, causing se_val=nan),
                 # estimate SE from the profile likelihood confidence interval width.
                 if not np.isfinite(se_val):
-                    if np.isfinite(ci_low) and np.isfinite(ci_high) and ci_low < ci_high:
-                        # Ensure the bounds actually crossed the threshold (are inside the grid)
+                    if (
+                        np.isfinite(ci_low)
+                        and np.isfinite(ci_high)
+                        and ci_low < ci_high
+                    ):
+                        # Ensure the bounds actually crossed the threshold
+                        # (are inside the grid)
                         if ci_low > min_val + 1e-6 and ci_high < max_val - 1e-6:
                             z_val = np.sqrt(critical_val)
                             dist = (ci_high - ci_low) / 2.0
@@ -529,7 +544,11 @@ class JumpDiffusionEstimator(BaseEstimator):
         """
         Plot the profile log-likelihood curves for each parameter.
         """
-        if not self.fitted or self.results is None or "profile_data" not in self.results:
+        if (
+            not self.fitted
+            or self.results is None
+            or "profile_data" not in self.results
+        ):
             print("Profile data not available. Run estimate_standard_errors() first.")
             return
 
@@ -578,8 +597,12 @@ class JumpDiffusionEstimator(BaseEstimator):
             # Filter finite values for plotting
             valid = np.isfinite(values)
             ax.plot(grid[valid], values[valid], "b-o", label="Profile Log-Lik")
-            ax.axvline(x=mle_val, color="red", linestyle="--", label=f"MLE: {mle_val:.4f}")
-            ax.axhline(y=threshold, color="green", linestyle=":", label="95% CI Threshold")
+            ax.axvline(
+                x=mle_val, color="red", linestyle="--", label=f"MLE: {mle_val:.4f}"
+            )
+            ax.axhline(
+                y=threshold, color="green", linestyle=":", label="95% CI Threshold"
+            )
 
             if np.isfinite(ci_low) and ci_low > grid.min():
                 ax.axvline(x=ci_low, color="green", linestyle="--", alpha=0.7)
@@ -629,14 +652,19 @@ class JumpDiffusionEstimator(BaseEstimator):
         print("=" * 60)
 
         if se_dict:
-            print(f"{'Parameter':<18} | {'Estimate':<10} | {'Std Error':<10} | {'95% Conf. Interval':<22}")
+            print(
+                f"{'Parameter':<18} | {'Estimate':<10} | "
+                f"{'Std Error':<10} | {'95% Conf. Interval':<22}"
+            )
             print("-" * 68)
             for name in self._param_names:
                 val = params[name]
                 se = se_dict.get(name, np.nan)
                 se_str = f"{se:.6f}" if np.isfinite(se) else "N/A"
                 ci = ci_dict.get(name, (np.nan, np.nan))
-                ci_str = f"[{ci[0]:.4f}, {ci[1]:.4f}]" if np.all(np.isfinite(ci)) else "N/A"
+                ci_str = (
+                    f"[{ci[0]:.4f}, {ci[1]:.4f}]" if np.all(np.isfinite(ci)) else "N/A"
+                )
                 print(f"{name:<18} | {val:<10.6f} | {se_str:<10} | {ci_str:<22}")
         else:
             print(f"Drift (μ):              {params['mu']:.6f}")

--- a/src/jump_diffusion/simulation/jump_diffusion_simulator.py
+++ b/src/jump_diffusion/simulation/jump_diffusion_simulator.py
@@ -160,7 +160,11 @@ class JumpDiffusionSimulator(BaseSimulator, JumpDiffusionModel):
             jumps = self.last_jumps
             jump_times = self.last_jump_times
         else:
-            jump_times = np.where(jumps != 0)[0] if jumps is not None else np.array([], dtype=int)
+            jump_times = (
+                np.where(jumps != 0)[0]
+                if jumps is not None
+                else np.array([], dtype=int)
+            )
 
         fig, axes = plt.subplots(2, 2, figsize=figsize)
 
@@ -256,5 +260,5 @@ class JumpDiffusionSimulator(BaseSimulator, JumpDiffusionModel):
         axes[1, 1].grid(True, alpha=0.3)
 
         plt.tight_layout()
-        
+
         return fig

--- a/src/jump_diffusion/validation/monte_carlo.py
+++ b/src/jump_diffusion/validation/monte_carlo.py
@@ -243,7 +243,9 @@ class ValidationExperiment:
             "jump_scale_up": "Jump Scale Up (η_up)",
             "jump_scale_down": "Jump Scale Down (η_down)",
         }
-        param_labels = [label_map.get(p, p.replace("_", " ").title()) for p in param_names]
+        param_labels = [
+            label_map.get(p, p.replace("_", " ").title()) for p in param_names
+        ]
 
         n_plots = len(param_names) + 1
         n_cols = 3

--- a/tests/test_estimation/test_standard_errors.py
+++ b/tests/test_estimation/test_standard_errors.py
@@ -1,7 +1,6 @@
 """Unit tests for the likelihood profiling standard errors calculation."""
 
 import numpy as np
-import pytest
 from jump_diffusion.distributions import NormalJump
 from jump_diffusion.estimation import JumpDiffusionEstimator
 from jump_diffusion.simulation import JumpDiffusionSimulator
@@ -47,14 +46,14 @@ def test_standard_errors_calculation_runs_and_estimates():
     # Run diagnostics to verify it prints standard errors table without crashing
     import io
     import sys
-    
+
     captured_output = io.StringIO()
     sys.stdout = captured_output
     try:
         estimator.diagnostics()
     finally:
         sys.stdout = sys.__stdout__
-        
+
     output_str = captured_output.getvalue()
     assert "Parameter" in output_str
     assert "Estimate" in output_str

--- a/tests/test_validation/test_monte_carlo.py
+++ b/tests/test_validation/test_monte_carlo.py
@@ -1,8 +1,6 @@
 """Unit tests for the ValidationExperiment class."""
 
-import numpy as np
-import pytest
-from jump_diffusion.distributions import NormalJump, KouJump, SkewNormalJump
+from jump_diffusion.distributions import NormalJump, KouJump
 from jump_diffusion.validation import ValidationExperiment
 
 
@@ -17,12 +15,14 @@ def test_validation_experiment_runs_with_default_skew_normal():
     }
     # SkewNormalJump is default
     experiment = ValidationExperiment(true_params)
-    results = experiment.run_experiment(n_simulations=2, T=0.1, n_steps=20, seed_base=42)
-    
+    results = experiment.run_experiment(
+        n_simulations=2, T=0.1, n_steps=20, seed_base=42
+    )
+
     assert len(results) > 0
     assert "mu_est" in results.columns
     assert "jump_skew_est" in results.columns
-    
+
     analysis = experiment.analyze_results()
     assert "mu" in analysis
     assert "jump_skew" in analysis
@@ -36,13 +36,15 @@ def test_validation_experiment_runs_with_normal():
         "jump_scale": 0.15,
     }
     experiment = ValidationExperiment(true_params, jump_distribution=NormalJump())
-    results = experiment.run_experiment(n_simulations=2, T=0.1, n_steps=20, seed_base=42)
-    
+    results = experiment.run_experiment(
+        n_simulations=2, T=0.1, n_steps=20, seed_base=42
+    )
+
     assert len(results) > 0
     assert "mu_est" in results.columns
     assert "jump_scale_est" in results.columns
     assert "jump_skew_est" not in results.columns
-    
+
     analysis = experiment.analyze_results()
     assert "mu" in analysis
     assert "jump_scale" in analysis
@@ -59,13 +61,15 @@ def test_validation_experiment_runs_with_kou():
         "jump_scale_down": 0.1,
     }
     experiment = ValidationExperiment(true_params, jump_distribution=KouJump())
-    results = experiment.run_experiment(n_simulations=2, T=0.1, n_steps=20, seed_base=42)
-    
+    results = experiment.run_experiment(
+        n_simulations=2, T=0.1, n_steps=20, seed_base=42
+    )
+
     assert len(results) > 0
     assert "mu_est" in results.columns
     assert "jump_scale_up_est" in results.columns
     assert "jump_scale_down_est" in results.columns
-    
+
     analysis = experiment.analyze_results()
     assert "mu" in analysis
     assert "jump_scale_up" in analysis


### PR DESCRIPTION
## Why

CI on `main` has been **red since PR #45** — every merge (#45–#49) failed. The failures are **not** in the tests; they are all in the **"Run linting"** step: accumulated `black` formatting drift plus `flake8` violations that were merged without running the linters locally.

Findings on `main`:
- `black --check` would reformat 7 files
- `flake8`: `E501` (lines > 88), `W293` (blank lines with whitespace), `F401` (unused imports) across `src/` and `tests/`

## What

Pure hygiene, **no behavior changes**:
- Apply `black` to the package (`normal.py`, `sged.py`, `maximum_likelihood.py`, `jump_diffusion_simulator.py`, `monte_carlo.py`)
- Wrap over-long comments / f-strings in `maximum_likelihood.py` and `sged.py`
- Remove unused imports in `test_standard_errors.py` and `test_monte_carlo.py`

## Verification (local)

- `black --check src/ tests/` → clean
- `flake8 src/ tests/` → 0 issues
- `mypy src/jump_diffusion` → success
- `pytest tests/` → **50 passed**

This restores a green baseline so subsequent feature work (Phase 1 inference: Wald / bootstrap / jump test) lands on top of passing CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)