### PR TITLE
feat: Add parametric bootstrap standard errors and confidence intervals

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -731,6 +731,131 @@ class JumpDiffusionEstimator(BaseEstimator):
             "confidence_intervals": confidence_intervals,
         }
 
+    def estimate_bootstrap_standard_errors(
+        self,
+        n_bootstrap: int = 200,
+        confidence_level: float = 0.95,
+        seed: Optional[int] = None,
+        **estimate_kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Estimate standard errors and confidence intervals by parametric
+        bootstrap.
+
+        This is the third inference route in the library, alongside the
+        profile likelihood intervals of :meth:`estimate_standard_errors` and
+        the Wald intervals of :meth:`estimate_wald_standard_errors`. It makes
+        no asymptotic-normality or regularity assumption, so it is the most
+        trustworthy of the three near a boundary (e.g. the jump probability
+        approaching zero) -- at the cost of re-fitting the model
+        ``n_bootstrap`` times.
+
+        The procedure is the textbook parametric bootstrap: treat the fitted
+        parameters as if they were the truth, simulate ``n_bootstrap`` fresh
+        datasets of the same length from that model, re-estimate the
+        parameters on each, and read the sampling variability directly off
+        the resulting replicate estimates. Standard errors are their
+        (ddof=1) standard deviation and confidence intervals are percentile
+        intervals.
+
+        Parameters:
+        -----------
+        n_bootstrap : int
+            Number of bootstrap replicates (model re-fits). More replicates
+            reduce Monte Carlo error in the standard errors and intervals
+            but scale the cost linearly.
+        confidence_level : float
+            Confidence level for the percentile intervals (e.g. 0.95).
+        seed : int, optional
+            Base seed for reproducibility. When given, replicate ``b`` is
+            simulated with seed ``seed + b``; when ``None`` the replicates
+            draw from NumPy's global random state and are not reproducible.
+        \\*\\*estimate_kwargs : dict
+            Forwarded to :meth:`estimate` for each replicate re-fit (e.g.
+            ``method="differential_evolution"``). Defaults to the same
+            gradient-based fit used elsewhere.
+
+        Returns:
+        --------
+        dict
+            Dictionary with ``standard_errors`` and
+            ``confidence_intervals`` (each keyed by parameter name), plus
+            ``n_successful`` -- the number of replicates whose re-fit
+            converged and contributed to the estimates. Non-converged
+            replicates are discarded. If fewer than two replicates succeed,
+            all standard errors and interval endpoints are ``nan``. The
+            results are also stored on ``self.results`` under
+            ``bootstrap_standard_errors``, ``bootstrap_confidence_intervals``
+            and ``bootstrap_estimates`` (the raw replicate matrix).
+
+        Raises:
+        -------
+        ValueError
+            If the model has not been fitted yet.
+        """
+        if not self.fitted or self.results is None:
+            raise ValueError("Model must be fitted first.")
+        results = self.results
+
+        fitted_params = results["parameters"]
+        jump_dist = self._model.jump_distribution
+
+        # Data-generating model: the fitted parameters treated as truth.
+        model = JumpDiffusionModel(jump_distribution=jump_dist, **fitted_params)
+        n_steps = self.n_obs
+        horizon = n_steps * self.dt
+
+        replicates: List[List[float]] = []
+        for b in range(n_bootstrap):
+            rep_seed = None if seed is None else seed + b
+            _, path, _ = model.simulate(
+                T=horizon, n_steps=n_steps, x0=0.0, seed=rep_seed
+            )
+            increments = np.diff(path)
+
+            estimator = JumpDiffusionEstimator(
+                increments, self.dt, jump_distribution=jump_dist
+            )
+            rep_result = estimator.estimate(**estimate_kwargs)
+            if rep_result["convergence"]:
+                rep_params = rep_result["parameters"]
+                replicates.append([rep_params[name] for name in self._param_names])
+
+        n_successful = len(replicates)
+
+        standard_errors: Dict[str, float] = {}
+        confidence_intervals: Dict[str, Tuple[float, float]] = {}
+
+        alpha = 1.0 - confidence_level
+        lower_pct, upper_pct = 100.0 * alpha / 2.0, 100.0 * (1.0 - alpha / 2.0)
+
+        if n_successful >= 2:
+            estimates = np.asarray(replicates, dtype=float)
+            ses = np.std(estimates, axis=0, ddof=1)
+            ci_lows = np.percentile(estimates, lower_pct, axis=0)
+            ci_highs = np.percentile(estimates, upper_pct, axis=0)
+            for idx, name in enumerate(self._param_names):
+                standard_errors[name] = float(ses[idx])
+                confidence_intervals[name] = (
+                    float(ci_lows[idx]),
+                    float(ci_highs[idx]),
+                )
+        else:
+            estimates = np.asarray(replicates, dtype=float)
+            for name in self._param_names:
+                standard_errors[name] = np.nan
+                confidence_intervals[name] = (np.nan, np.nan)
+
+        results["bootstrap_standard_errors"] = standard_errors
+        results["bootstrap_confidence_intervals"] = confidence_intervals
+        results["bootstrap_estimates"] = estimates
+
+        return {
+            "standard_errors": standard_errors,
+            "confidence_intervals": confidence_intervals,
+            "n_successful": n_successful,
+        }
+
     def plot_profiles(self, figsize: Tuple[float, float] = (15, 10)) -> None:
         """
         Plot the profile log-likelihood curves for each parameter.

--- a/tests/test_estimation/test_bootstrap_standard_errors.py
+++ b/tests/test_estimation/test_bootstrap_standard_errors.py
@@ -1,0 +1,83 @@
+"""Unit tests for the parametric bootstrap standard errors."""
+
+import numpy as np
+import pytest
+from jump_diffusion.distributions import NormalJump
+from jump_diffusion.estimation import JumpDiffusionEstimator
+from jump_diffusion.simulation import JumpDiffusionSimulator
+
+
+def _fit_normal_jump(seed: int = 123):
+    """Simulate a moderate Normal-jump dataset and fit an estimator to it."""
+    true_params = {
+        "mu": 0.05,
+        "sigma": 0.2,
+        "jump_prob": 0.1,
+        "jump_scale": 0.15,
+    }
+    sim = JumpDiffusionSimulator(jump_distribution=NormalJump(), **true_params)
+    times, path, _ = sim.simulate_path(T=1.0, n_steps=300, x0=100.0, seed=seed)
+    increments = np.diff(path)
+    dt = times[1] - times[0]
+
+    estimator = JumpDiffusionEstimator(increments, dt, jump_distribution=NormalJump())
+    results = estimator.estimate()
+    return estimator, results
+
+
+def test_bootstrap_standard_errors_structure_and_values():
+    estimator, results = _fit_normal_jump()
+
+    boot = estimator.estimate_bootstrap_standard_errors(
+        n_bootstrap=20, confidence_level=0.95, seed=0
+    )
+
+    assert "standard_errors" in boot
+    assert "confidence_intervals" in boot
+    assert boot["n_successful"] > 0
+
+    for param in ("mu", "sigma", "jump_prob"):
+        se = boot["standard_errors"][param]
+        assert np.isfinite(se)
+        assert se > 0
+
+        ci_low, ci_high = boot["confidence_intervals"][param]
+        assert np.isfinite(ci_low) and np.isfinite(ci_high)
+        assert ci_low < ci_high
+
+    # The point estimate should sit inside its percentile interval, since
+    # replicates are simulated from the fitted parameters themselves.
+    ci_low, ci_high = boot["confidence_intervals"]["sigma"]
+    assert ci_low <= results["parameters"]["sigma"] <= ci_high
+
+
+def test_bootstrap_results_are_stored_on_estimator():
+    estimator, _ = _fit_normal_jump()
+    estimator.estimate_bootstrap_standard_errors(n_bootstrap=10, seed=0)
+
+    assert "bootstrap_standard_errors" in estimator.results
+    assert "bootstrap_confidence_intervals" in estimator.results
+    assert "bootstrap_estimates" in estimator.results
+
+    estimates = np.asarray(estimator.results["bootstrap_estimates"])
+    # One row per successful replicate, one column per parameter.
+    assert estimates.shape[1] == len(estimator._param_names)
+
+
+def test_bootstrap_is_reproducible_with_seed():
+    estimator, _ = _fit_normal_jump()
+
+    first = estimator.estimate_bootstrap_standard_errors(n_bootstrap=10, seed=42)
+    second = estimator.estimate_bootstrap_standard_errors(n_bootstrap=10, seed=42)
+
+    for param in estimator._param_names:
+        assert first["standard_errors"][param] == pytest.approx(
+            second["standard_errors"][param]
+        )
+
+
+def test_bootstrap_requires_fitted_model():
+    increments = np.random.default_rng(0).normal(size=100) * 0.1
+    estimator = JumpDiffusionEstimator(increments, dt=1.0 / 252)
+    with pytest.raises(ValueError):
+        estimator.estimate_bootstrap_standard_errors(n_bootstrap=5)


### PR DESCRIPTION
Second increment of **Phase 1** (likelihood-based inference), after Wald (#51).

## What

Adds `estimate_bootstrap_standard_errors()` to `JumpDiffusionEstimator` — the **third inference route** alongside profile likelihood (`estimate_standard_errors`) and Wald (`estimate_wald_standard_errors`).

Textbook **parametric bootstrap**: treat the fitted parameters as truth, simulate `n_bootstrap` fresh datasets of the same length, re-estimate on each, and read the sampling variability off the replicate estimates.
- Standard errors = replicate std (ddof=1).
- Confidence intervals = percentile intervals.

## Why

The bootstrap makes **no asymptotic-normality or regularity assumption**, so it is the most trustworthy of the three routes exactly where Wald/Wilks are suspect — near a boundary such as the jump probability approaching zero. Having all three side by side is what enables the planned finite-sample **coverage comparison** (RQ1 in the scoping doc).

## Details

- Reproducible via a base `seed` (replicate `b` uses `seed + b`).
- Non-converged replicates are discarded; `n_successful` is returned. With fewer than two successes, SEs and interval endpoints are `nan`.
- `**estimate_kwargs` are forwarded to each replicate re-fit (e.g. `method="differential_evolution"`).
- Results stored on `self.results` under `bootstrap_standard_errors`, `bootstrap_confidence_intervals`, `bootstrap_estimates`.

## Tests

4 new unit tests: structure/values (with the point estimate falling inside its percentile interval), result storage, seed reproducibility, fitted-model guard.

## Verification (local)

- `black --check` / `flake8` / `mypy` → clean
- `pytest tests/` → **59 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)