### PR TITLE
feat: Add parametric bootstrap test for the presence of jumps

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -856,6 +856,145 @@ class JumpDiffusionEstimator(BaseEstimator):
             "n_successful": n_successful,
         }
 
+    def _pure_diffusion_log_likelihood(
+        self, increments: np.ndarray
+    ) -> Tuple[float, float, float]:
+        """
+        Maximized log-likelihood under the no-jump null (pure diffusion).
+
+        Under ``H0: jump_prob = 0`` the increments are i.i.d. Gaussian, so
+        the maximum likelihood fit is available in closed form: the mean and
+        (population, MLE) standard deviation of the increments. This returns
+        that maximized log-likelihood together with the two fitted moments,
+        which also parameterize the data-generating process for the
+        bootstrap in :meth:`test_for_jumps`.
+
+        Parameters:
+        -----------
+        increments : np.ndarray
+            One-dimensional array of increments.
+
+        Returns:
+        --------
+        tuple
+            ``(log_likelihood, mean, std)``. ``log_likelihood`` is
+            ``-inf`` when the increments are constant (``std == 0``).
+        """
+        mean = float(np.mean(increments))
+        std = float(np.std(increments))  # ddof=0 -> the Gaussian MLE
+        if std <= 0:
+            return -np.inf, mean, std
+        log_lik = float(np.sum(stats.norm.logpdf(increments, loc=mean, scale=std)))
+        return log_lik, mean, std
+
+    def test_for_jumps(
+        self,
+        n_bootstrap: int = 200,
+        seed: Optional[int] = None,
+        **estimate_kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Test for the presence of jumps via a parametric bootstrap likelihood
+        ratio test of ``H0: jump_prob = 0`` (pure diffusion) against
+        ``H1: jump_prob > 0``.
+
+        The statistic is the usual likelihood ratio
+        ``LR = 2 * (loglik_full - loglik_null)``, where ``loglik_full`` is
+        the maximized jump-diffusion log-likelihood (already available from
+        the fit) and ``loglik_null`` is the closed-form maximized Gaussian
+        log-likelihood (see :meth:`_pure_diffusion_log_likelihood`).
+
+        Its asymptotic null distribution is **non-standard**: under ``H0``
+        the jump probability sits on the boundary of the parameter space
+        (Chernoff, 1954; Self & Liang, 1987) *and* the jump-size parameters
+        become unidentified (Davies, 1977, 1987) -- so the usual chi-squared
+        calibration does not apply. We therefore obtain the p-value by
+        parametric bootstrap (a Monte Carlo test): simulate ``n_bootstrap``
+        pure-diffusion datasets from the fitted null model, recompute the LR
+        statistic on each, and compare the observed statistic against that
+        simulated null distribution. This sidesteps both pathologies by
+        construction.
+
+        Parameters:
+        -----------
+        n_bootstrap : int
+            Number of bootstrap datasets drawn under the null. Each requires
+            re-fitting the full jump-diffusion model, so cost scales
+            linearly.
+        seed : int, optional
+            Seed for the bootstrap data generation, for reproducibility.
+        \\*\\*estimate_kwargs : dict
+            Forwarded to :meth:`estimate` for each bootstrap re-fit.
+
+        Returns:
+        --------
+        dict
+            Dictionary with:
+
+            * ``lr_statistic`` -- observed likelihood ratio statistic.
+            * ``p_value`` -- bootstrap p-value
+              ``(1 + #{LR* >= LR_obs}) / (n_successful + 1)``; ``nan`` if no
+              bootstrap re-fit converged.
+            * ``log_likelihood_full`` / ``log_likelihood_null`` -- the two
+              maximized log-likelihoods on the observed data.
+            * ``n_bootstrap`` / ``n_successful`` -- requested and converged
+              replicate counts.
+            * ``bootstrap_statistics`` -- the simulated null LR values.
+
+            The result is also stored on ``self.results`` under
+            ``jump_test``.
+
+        Raises:
+        -------
+        ValueError
+            If the model has not been fitted yet.
+        """
+        if not self.fitted or self.results is None:
+            raise ValueError("Model must be fitted first.")
+        results = self.results
+
+        log_lik_full = results["log_likelihood"]
+        log_lik_null, mean0, std0 = self._pure_diffusion_log_likelihood(self.increments)
+        # The full model nests the null, so LR is non-negative in theory;
+        # clamp to guard against the optimizer stopping just short of it.
+        lr_observed = max(0.0, 2.0 * (log_lik_full - log_lik_null))
+
+        jump_dist = self._model.jump_distribution
+        rng = np.random.default_rng(seed)
+
+        bootstrap_stats: List[float] = []
+        for _ in range(n_bootstrap):
+            increments_b = rng.normal(mean0, std0, size=self.n_obs)
+            estimator = JumpDiffusionEstimator(
+                increments_b, self.dt, jump_distribution=jump_dist
+            )
+            rep_result = estimator.estimate(**estimate_kwargs)
+            if not rep_result["convergence"]:
+                continue
+            log_lik_full_b = rep_result["log_likelihood"]
+            log_lik_null_b, _, _ = self._pure_diffusion_log_likelihood(increments_b)
+            bootstrap_stats.append(max(0.0, 2.0 * (log_lik_full_b - log_lik_null_b)))
+
+        n_successful = len(bootstrap_stats)
+        stats_array = np.asarray(bootstrap_stats, dtype=float)
+        if n_successful >= 1:
+            exceed = int(np.sum(stats_array >= lr_observed))
+            p_value = (1.0 + exceed) / (n_successful + 1.0)
+        else:
+            p_value = np.nan
+
+        jump_test = {
+            "lr_statistic": lr_observed,
+            "p_value": p_value,
+            "log_likelihood_full": log_lik_full,
+            "log_likelihood_null": log_lik_null,
+            "n_bootstrap": n_bootstrap,
+            "n_successful": n_successful,
+            "bootstrap_statistics": stats_array,
+        }
+        results["jump_test"] = jump_test
+        return jump_test
+
     def plot_profiles(self, figsize: Tuple[float, float] = (15, 10)) -> None:
         """
         Plot the profile log-likelihood curves for each parameter.

--- a/tests/test_estimation/test_jump_test.py
+++ b/tests/test_estimation/test_jump_test.py
@@ -1,0 +1,74 @@
+"""Unit tests for the parametric bootstrap test for the presence of jumps."""
+
+import numpy as np
+import pytest
+from jump_diffusion.distributions import NormalJump
+from jump_diffusion.estimation import JumpDiffusionEstimator
+from jump_diffusion.simulation import JumpDiffusionSimulator
+
+
+def _fit_with_jumps(seed: int = 123):
+    """Fit an estimator on data that genuinely contains jumps."""
+    true_params = {
+        "mu": 0.05,
+        "sigma": 0.2,
+        "jump_prob": 0.1,
+        "jump_scale": 0.15,
+    }
+    sim = JumpDiffusionSimulator(jump_distribution=NormalJump(), **true_params)
+    times, path, _ = sim.simulate_path(T=1.0, n_steps=300, x0=100.0, seed=seed)
+    increments = np.diff(path)
+    dt = times[1] - times[0]
+
+    estimator = JumpDiffusionEstimator(increments, dt, jump_distribution=NormalJump())
+    estimator.estimate()
+    return estimator
+
+
+def _fit_pure_diffusion(seed: int = 7):
+    """Fit an estimator on pure-diffusion (no-jump) data."""
+    rng = np.random.default_rng(seed)
+    dt = 1.0 / 252
+    increments = rng.normal(0.05 * dt, 0.2 * np.sqrt(dt), size=300)
+    estimator = JumpDiffusionEstimator(increments, dt, jump_distribution=NormalJump())
+    estimator.estimate()
+    return estimator
+
+
+def test_jump_test_detects_jumps():
+    estimator = _fit_with_jumps()
+    result = estimator.test_for_jumps(n_bootstrap=30, seed=0)
+
+    assert 0.0 <= result["p_value"] <= 1.0
+    assert result["lr_statistic"] > 0.0
+    assert result["n_successful"] > 0
+    # The jumps here dwarf the diffusion, so the test should reject H0.
+    assert result["p_value"] < 0.2
+
+
+def test_jump_test_structure_under_null():
+    estimator = _fit_pure_diffusion()
+    result = estimator.test_for_jumps(n_bootstrap=30, seed=0)
+
+    assert 0.0 <= result["p_value"] <= 1.0
+    assert result["lr_statistic"] >= 0.0
+    assert result["log_likelihood_full"] >= result["log_likelihood_null"] - 1e-6
+    assert len(result["bootstrap_statistics"]) == result["n_successful"]
+
+
+def test_jump_test_is_stored_and_reproducible():
+    estimator = _fit_with_jumps()
+
+    first = estimator.test_for_jumps(n_bootstrap=15, seed=42)
+    assert "jump_test" in estimator.results
+
+    second = estimator.test_for_jumps(n_bootstrap=15, seed=42)
+    assert first["p_value"] == pytest.approx(second["p_value"])
+    assert first["lr_statistic"] == pytest.approx(second["lr_statistic"])
+
+
+def test_jump_test_requires_fitted_model():
+    increments = np.random.default_rng(0).normal(size=100) * 0.1
+    estimator = JumpDiffusionEstimator(increments, dt=1.0 / 252)
+    with pytest.raises(ValueError):
+        estimator.test_for_jumps(n_bootstrap=5)


### PR DESCRIPTION
Third increment of **Phase 1** (likelihood-based inference), after Wald (#51) and bootstrap CIs (#52). This is the methodological centrepiece flagged in the scoping doc (RQ3).

## What

Adds `test_for_jumps()` to `JumpDiffusionEstimator`: a likelihood ratio test of **H0: `jump_prob = 0`** (pure diffusion) vs **H1: `jump_prob > 0`**.

- Statistic: `LR = 2 * (loglik_full - loglik_null)`, with `loglik_null` the closed-form maximized Gaussian log-likelihood (new helper `_pure_diffusion_log_likelihood`).
- p-value by **parametric bootstrap** (Monte Carlo test).

## Why not a chi-squared

The asymptotic null distribution of `LR` here is **non-standard** for two reasons that hold simultaneously:

1. **Boundary.** Under H0, `jump_prob` sits on the edge of `[0, 1]` (Chernoff 1954; Self & Liang 1987).
2. **Unidentified nuisance parameters.** When `jump_prob = 0`, the jump-size parameters drop out of the likelihood (Davies 1977, 1987).

Standard Wilks calibration is therefore invalid. The parametric bootstrap sidesteps both pathologies by construction: simulate `n_bootstrap` pure-diffusion datasets from the fitted null, recompute `LR` on each, and compare the observed statistic against that simulated null distribution.

## Details

- Reproducible via `seed`; non-converged replicates skipped, `n_successful` reported.
- `p_value = (1 + #{LR* >= LR_obs}) / (n_successful + 1)`.
- `LR` clamped at 0 (the full model nests the null; guards against the optimizer stopping just short).
- Result stored on `self.results` under `jump_test`.

## Tests

4 new unit tests: **power** (rejects on data with real jumps), structure under the null, storage + seed reproducibility, fitted-model guard.

## Verification (local)

- `black --check` / `flake8` / `mypy` → clean
- `pytest tests/` → **63 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)