### PR TITLE
fix: Make KS goodness-of-fit a valid parametric bootstrap test

### DIFF
--- a/src/jump_diffusion/validation/distribution_comparison.py
+++ b/src/jump_diffusion/validation/distribution_comparison.py
@@ -3,9 +3,12 @@ Jump-distribution goodness-of-fit comparison.
 
 This module fits JumpDiffusionEstimator under several candidate jump-size
 distributions on the same data and compares how well each one fits, via
-information criteria (AIC/BIC) and a simulation-based Kolmogorov-Smirnov
-test. The KS test only relies on ``JumpDistribution.rvs``, so it works the
-same way for any current or future jump distribution.
+information criteria (AIC/BIC) and a Kolmogorov-Smirnov goodness-of-fit
+test whose p-value is obtained by parametric bootstrap, so it accounts for
+the fact that the parameters were estimated from the same data. The KS
+machinery only relies on ``JumpDistribution.rvs`` (through model
+simulation), so it works the same way for any current or future jump
+distribution.
 """
 
 from typing import Any, Dict, Optional, Tuple
@@ -39,15 +42,92 @@ class JumpDistributionComparison:
         self.dt = dt
         self.results: Dict[str, Dict[str, Any]] = {}
 
+    def _simulate_increments(
+        self,
+        model: JumpDiffusionModel,
+        size: int,
+        seed: Optional[int],
+    ) -> np.ndarray:
+        """Simulate ``size`` increments from ``model`` at this object's dt."""
+        _, path, _ = model.simulate(T=size * self.dt, n_steps=size, x0=0.0, seed=seed)
+        return np.diff(path)
+
+    def _parametric_bootstrap_ks_pvalue(
+        self,
+        jump_distribution: JumpDistribution,
+        fitted_model: JumpDiffusionModel,
+        ks_observed: float,
+        n_obs: int,
+        reference_size: int,
+        n_bootstrap: int,
+        seed: Optional[int],
+        estimate_kwargs: Dict[str, Any],
+    ) -> float:
+        """
+        Monte Carlo p-value for the KS goodness-of-fit statistic.
+
+        A plain two-sample KS p-value is invalid here because the reference
+        distribution was estimated from the very data being tested, which
+        makes the naive p-value strongly anti-conservative. The parametric
+        bootstrap restores validity: under the fitted (null) model we
+        simulate ``n_bootstrap`` datasets of the observed size, **re-fit** the
+        model on each, and recompute the KS distance of each dataset to its
+        own re-fitted model. The fraction of these bootstrap distances that
+        equal or exceed the observed one estimates the p-value, with the
+        usual ``(1 + count) / (n_successful + 1)`` small-sample correction.
+        Re-fitting inside the loop is what makes the test account for
+        estimation error.
+
+        Returns ``nan`` if ``n_bootstrap <= 0`` or no replicate converged.
+        """
+        if n_bootstrap <= 0:
+            return float("nan")
+
+        exceed = 0
+        n_successful = 0
+        for b in range(n_bootstrap):
+            data_seed = None if seed is None else seed + 1000 + b
+            boot_data = self._simulate_increments(fitted_model, n_obs, data_seed)
+
+            estimator = JumpDiffusionEstimator(
+                boot_data, self.dt, jump_distribution=jump_distribution
+            )
+            rep_result = estimator.estimate(**estimate_kwargs)
+            if not rep_result["convergence"]:
+                continue
+
+            model_b = JumpDiffusionModel(
+                jump_distribution=jump_distribution, **rep_result["parameters"]
+            )
+            ref_seed = None if seed is None else seed + 100_000 + b
+            reference_b = self._simulate_increments(model_b, reference_size, ref_seed)
+            ks_b = float(ks_2samp(boot_data, reference_b).statistic)
+            if ks_b >= ks_observed:
+                exceed += 1
+            n_successful += 1
+
+        if n_successful == 0:
+            return float("nan")
+        return (1.0 + exceed) / (n_successful + 1.0)
+
     def fit(
         self,
         name: str,
         jump_distribution: JumpDistribution,
         seed: Optional[int] = None,
+        n_bootstrap: int = 199,
+        ks_reference_size: Optional[int] = None,
         **estimate_kwargs: Any,
     ) -> Dict[str, Any]:
         r"""
         Fit ``jump_distribution`` to the data and record its goodness of fit.
+
+        The KS statistic is the distance between the data and the fitted
+        model's distribution, the latter approximated by a large simulated
+        reference sample so that simulation noise in the statistic itself is
+        negligible. Its p-value is obtained by parametric bootstrap (see
+        :meth:`_parametric_bootstrap_ks_pvalue`), which is the dominant cost
+        of this method.
 
         Parameters:
         -----------
@@ -56,16 +136,29 @@ class JumpDistributionComparison:
         jump_distribution : JumpDistribution
             Jump-size distribution to fit.
         seed : int, optional
-            Random seed for the simulation-based KS test.
+            Base random seed. When given, the reference sample, the plotting
+            sample and every bootstrap replicate use distinct derived seeds,
+            so the whole ``fit`` is reproducible.
+        n_bootstrap : int
+            Number of parametric bootstrap replicates for the KS p-value.
+            Each re-fits the model, so cost scales linearly; set to ``0`` to
+            skip the p-value (it is then reported as ``nan``).
+        ks_reference_size : int, optional
+            Size of the reference sample used to evaluate the KS statistic.
+            Defaults to ``max(20 * n_obs, 20000)``. Larger values give a
+            more stable statistic at higher simulation cost.
         \*\*estimate_kwargs : dict
             Additional arguments forwarded to
-            ``JumpDiffusionEstimator.estimate``.
+            ``JumpDiffusionEstimator.estimate`` (also used for every
+            bootstrap re-fit).
 
         Returns:
         --------
         dict
             The estimation results, extended with ``ks_statistic``,
-            ``ks_pvalue`` and ``simulated_increments``.
+            ``ks_pvalue`` (parametric bootstrap), ``ks_n_bootstrap`` and
+            ``simulated_increments`` (an observation-sized sample kept for
+            :meth:`plot_comparison`).
         """
         estimator = JumpDiffusionEstimator(
             self.data, self.dt, jump_distribution=jump_distribution
@@ -76,14 +169,39 @@ class JumpDistributionComparison:
             jump_distribution=jump_distribution, **result["parameters"]
         )
         n_obs = len(self.data)
-        _, simulated_path, _ = fitted_model.simulate(
-            T=n_obs * self.dt, n_steps=n_obs, x0=0.0, seed=seed
+        reference_size = (
+            ks_reference_size
+            if ks_reference_size is not None
+            else max(20 * n_obs, 20000)
         )
-        simulated_increments = np.diff(simulated_path)
 
-        ks_statistic, ks_pvalue = ks_2samp(self.data, simulated_increments)
+        # Stable KS distance to the fitted model, via a large reference
+        # sample so the statistic is not dominated by simulation noise.
+        ref_seed = None if seed is None else seed
+        reference_increments = self._simulate_increments(
+            fitted_model, reference_size, ref_seed
+        )
+        ks_statistic = float(ks_2samp(self.data, reference_increments).statistic)
+
+        # A same-size sample kept only for the histogram overlay in
+        # plot_comparison (not used by the statistic).
+        plot_seed = None if seed is None else seed + 1
+        simulated_increments = self._simulate_increments(fitted_model, n_obs, plot_seed)
+
+        ks_pvalue = self._parametric_bootstrap_ks_pvalue(
+            jump_distribution,
+            fitted_model,
+            ks_statistic,
+            n_obs,
+            reference_size,
+            n_bootstrap,
+            seed,
+            estimate_kwargs,
+        )
+
         result["ks_statistic"] = ks_statistic
         result["ks_pvalue"] = ks_pvalue
+        result["ks_n_bootstrap"] = n_bootstrap
         result["simulated_increments"] = simulated_increments
 
         self.results[name] = result

--- a/tests/test_validation/test_distribution_comparison.py
+++ b/tests/test_validation/test_distribution_comparison.py
@@ -27,18 +27,41 @@ class TestJumpDistributionComparison:
 
     def test_fit_returns_ks_fields(self):
         comparison = JumpDistributionComparison(self.increments, self.dt)
-        result = comparison.fit("Normal", NormalJump(), seed=1)
+        result = comparison.fit(
+            "Normal", NormalJump(), seed=1, n_bootstrap=15, ks_reference_size=2000
+        )
 
         assert "ks_statistic" in result
         assert "ks_pvalue" in result
         assert 0.0 <= result["ks_pvalue"] <= 1.0
+        assert result["ks_n_bootstrap"] == 15
         assert np.isfinite(result["aic"])
         assert np.isfinite(result["bic"])
 
+    def test_bootstrap_pvalue_can_be_skipped(self):
+        comparison = JumpDistributionComparison(self.increments, self.dt)
+        result = comparison.fit(
+            "Normal", NormalJump(), seed=1, n_bootstrap=0, ks_reference_size=2000
+        )
+
+        # Opting out of the bootstrap still yields a (stable) statistic but
+        # no p-value.
+        assert np.isfinite(result["ks_statistic"])
+        assert np.isnan(result["ks_pvalue"])
+
+    def test_bootstrap_pvalue_is_reproducible_with_seed(self):
+        first = JumpDistributionComparison(self.increments, self.dt).fit(
+            "Normal", NormalJump(), seed=3, n_bootstrap=12, ks_reference_size=2000
+        )
+        second = JumpDistributionComparison(self.increments, self.dt).fit(
+            "Normal", NormalJump(), seed=3, n_bootstrap=12, ks_reference_size=2000
+        )
+        assert first["ks_pvalue"] == second["ks_pvalue"]
+
     def test_compare_ranks_by_aic(self):
         comparison = JumpDistributionComparison(self.increments, self.dt)
-        comparison.fit("Normal", NormalJump(), seed=1)
-        comparison.fit("SkewNormal", SkewNormalJump(), seed=1)
+        comparison.fit("Normal", NormalJump(), seed=1, n_bootstrap=10)
+        comparison.fit("SkewNormal", SkewNormalJump(), seed=1, n_bootstrap=10)
 
         table = comparison.compare()
 


### PR DESCRIPTION
Final increment of **Phase 1** (likelihood-based inference). Fixes the goodness-of-fit weakness flagged in the scoping doc (§5.4).

## Problem

`JumpDistributionComparison.fit` compared the data against a **single** simulation of the same size via `ks_2samp`. Two statistical flaws:

1. The statistic was dominated by the noise of one n-sized sample.
2. The p-value was **invalid** — the reference distribution was estimated from the very data being tested, making the naive two-sample p-value strongly anti-conservative.

## Fix

A proper parametric-bootstrap goodness-of-fit test:

- **Stable statistic.** The KS distance is now measured between the data and the fitted model's distribution, the latter approximated by a **large reference sample** (default `max(20·n_obs, 20000)`), so simulation noise in the statistic is negligible.
- **Valid p-value.** New helper `_parametric_bootstrap_ks_pvalue`: simulate `n_bootstrap` datasets under the fitted null, **re-fit the model on each**, recompute each dataset's KS distance to its own re-fitted model, and compare against the observed distance. Re-fitting inside the loop is what makes the test account for estimation error. Uses the `(1 + count)/(n_successful + 1)` correction.

## API

New `fit()` parameters: `n_bootstrap` (default `199`; `0` skips the p-value → `nan`) and `ks_reference_size`. Fully reproducible seeding across the reference, plotting sample and every replicate. A same-size `simulated_increments` sample is still returned for `plot_comparison`.

## Tests

Existing tests updated to pass a small `n_bootstrap` for speed; adds tests for the skip path (`n_bootstrap=0` → `nan`) and seed reproducibility.

## Verification (local)

- `black --check` / `flake8` / `mypy` → clean
- `pytest tests/` → **65 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)