### PR TITLE
feat: Add public param_names property and summary() inference table

### DIFF
--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -6,6 +6,7 @@ mixture likelihood implemented on the model itself.
 """
 
 import numpy as np
+import pandas as pd
 import warnings
 from scipy import stats
 from scipy.optimize import Bounds, differential_evolution, minimize
@@ -72,6 +73,18 @@ class JumpDiffusionEstimator(BaseEstimator):
         self.std_increment = float(np.std(self.increments))
         self.skewness = float(stats.skew(self.increments))
         self.kurtosis = float(stats.kurtosis(self.increments))
+
+    @property
+    def param_names(self) -> Tuple[str, ...]:
+        """
+        Ordered parameter names for this estimator.
+
+        Always ``("mu", "sigma", "jump_prob", *jump_distribution.param_names)``.
+        This is the order used by every parameter vector, standard-error and
+        confidence-interval dictionary the estimator produces, so it is the
+        natural key for iterating over results.
+        """
+        return self._param_names
 
     def log_likelihood(self, params: np.ndarray) -> float:
         """
@@ -994,6 +1007,74 @@ class JumpDiffusionEstimator(BaseEstimator):
         }
         results["jump_test"] = jump_test
         return jump_test
+
+    def summary(self) -> pd.DataFrame:
+        """
+        Tidy table of the estimates and every inference route computed so far.
+
+        Returns one row per parameter with its point ``estimate`` plus, for
+        each inference method that has been run, the standard error and
+        confidence interval bounds. Columns are only added for methods that
+        were actually computed:
+
+        * ``estimate_standard_errors`` -> ``profile_se``, ``profile_ci_low``,
+          ``profile_ci_high``
+        * ``estimate_wald_standard_errors`` -> ``wald_se``, ``wald_ci_low``,
+          ``wald_ci_high``
+        * ``estimate_bootstrap_standard_errors`` -> ``bootstrap_se``,
+          ``bootstrap_ci_low``, ``bootstrap_ci_high``
+
+        This is the structured counterpart to :meth:`diagnostics` (which
+        prints a single-method table): it puts the profile, Wald and
+        bootstrap results side by side, which is exactly what a coverage
+        comparison or a results table for a paper needs.
+
+        Returns:
+        --------
+        pandas.DataFrame
+            One row per parameter, indexed by insertion order, with an
+            ``estimate`` column and the SE/CI columns of whichever methods
+            have been run.
+
+        Raises:
+        -------
+        ValueError
+            If the model has not been fitted yet.
+        """
+        if not self.fitted or self.results is None:
+            raise ValueError("Model must be fitted first.")
+        results = self.results
+        params = results["parameters"]
+
+        # (label, standard-errors key, confidence-intervals key)
+        method_keys = [
+            ("profile", "standard_errors", "confidence_intervals"),
+            ("wald", "wald_standard_errors", "wald_confidence_intervals"),
+            (
+                "bootstrap",
+                "bootstrap_standard_errors",
+                "bootstrap_confidence_intervals",
+            ),
+        ]
+
+        rows = []
+        for name in self._param_names:
+            row: Dict[str, Any] = {
+                "parameter": name,
+                "estimate": params[name],
+            }
+            for label, se_key, ci_key in method_keys:
+                se_dict = results.get(se_key)
+                if se_dict is None:
+                    continue
+                ci_dict = results.get(ci_key) or {}
+                ci_low, ci_high = ci_dict.get(name, (np.nan, np.nan))
+                row[f"{label}_se"] = se_dict.get(name, np.nan)
+                row[f"{label}_ci_low"] = ci_low
+                row[f"{label}_ci_high"] = ci_high
+            rows.append(row)
+
+        return pd.DataFrame(rows)
 
     def plot_profiles(self, figsize: Tuple[float, float] = (15, 10)) -> None:
         """

--- a/tests/test_estimation/test_summary.py
+++ b/tests/test_estimation/test_summary.py
@@ -1,0 +1,68 @@
+"""Unit tests for the public param_names property and summary() table."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from jump_diffusion.distributions import NormalJump
+from jump_diffusion.estimation import JumpDiffusionEstimator
+from jump_diffusion.simulation import JumpDiffusionSimulator
+
+
+def _fit_normal_jump(seed: int = 123):
+    true_params = {
+        "mu": 0.05,
+        "sigma": 0.2,
+        "jump_prob": 0.1,
+        "jump_scale": 0.15,
+    }
+    sim = JumpDiffusionSimulator(jump_distribution=NormalJump(), **true_params)
+    times, path, _ = sim.simulate_path(T=1.0, n_steps=300, x0=100.0, seed=seed)
+    increments = np.diff(path)
+    dt = times[1] - times[0]
+
+    estimator = JumpDiffusionEstimator(increments, dt, jump_distribution=NormalJump())
+    estimator.estimate()
+    return estimator
+
+
+def test_param_names_is_public_and_ordered():
+    estimator = _fit_normal_jump()
+    assert estimator.param_names == estimator._param_names
+    assert estimator.param_names[:3] == ("mu", "sigma", "jump_prob")
+
+
+def test_summary_before_any_inference_has_only_estimates():
+    estimator = _fit_normal_jump()
+    table = estimator.summary()
+
+    assert isinstance(table, pd.DataFrame)
+    assert list(table["parameter"]) == list(estimator.param_names)
+    assert "estimate" in table.columns
+    # No inference route has been run, so no SE columns should be present.
+    assert not any(col.endswith("_se") for col in table.columns)
+
+
+def test_summary_collects_all_three_inference_routes():
+    estimator = _fit_normal_jump()
+    estimator.estimate_standard_errors(n_points=7)
+    estimator.estimate_wald_standard_errors()
+    estimator.estimate_bootstrap_standard_errors(n_bootstrap=15, seed=0)
+
+    table = estimator.summary()
+
+    for label in ("profile", "wald", "bootstrap"):
+        for suffix in ("_se", "_ci_low", "_ci_high"):
+            assert f"{label}{suffix}" in table.columns
+
+    # sigma is well identified: finite, positive SE from every route.
+    sigma_row = table.set_index("parameter").loc["sigma"]
+    for label in ("profile", "wald", "bootstrap"):
+        assert np.isfinite(sigma_row[f"{label}_se"])
+        assert sigma_row[f"{label}_se"] > 0
+
+
+def test_summary_requires_fitted_model():
+    increments = np.random.default_rng(0).normal(size=100) * 0.1
+    estimator = JumpDiffusionEstimator(increments, dt=1.0 / 252)
+    with pytest.raises(ValueError):
+        estimator.summary()


### PR DESCRIPTION
Groundwork for the v0.2 tutorial. Dogfooding the full API end-to-end (an API shakedown) surfaced two rough edges this fixes **before** the release.

## Friction found

Showing the three inference routes (profile / Wald / bootstrap) side by side — the tutorial's centrepiece — forced callers to:
1. juggle three separate result dicts by hand, and
2. reach into the **private** `_param_names` attribute to iterate.

## Fix

- **`param_names`** — public read-only property exposing the ordered names `(mu, sigma, jump_prob, *jump params)` that every result dict is keyed by.
- **`summary()`** — returns a tidy `pandas.DataFrame`: one row per parameter, its point `estimate`, and the SE/CI columns of whichever inference methods have been run (`profile_*`, `wald_*`, `bootstrap_*`). Columns appear only for methods actually computed. It's the structured counterpart to `diagnostics()` and the natural results table for a coverage comparison or a paper.

Example output:

```
 parameter  estimate  profile_se  profile_ci_low  ...  bootstrap_se  bootstrap_ci_low  bootstrap_ci_high
        mu   -0.0000      0.2090         -0.4103  ...        0.2699           -0.5792             0.2939
     sigma    0.1921      0.0086          0.1771  ...        0.0094            0.1803             0.2072
 jump_prob    0.1125      0.0204          0.0772  ...        0.0196            0.0680             0.1350
jump_scale    0.1404      0.0180          0.1141  ...        0.0182            0.1231             0.1877
```

## Tests

4 new tests: public property, empty-inference summary, all-three-routes summary, fitted-model guard.

## Verification (local)

- `black --check` / `flake8` / `mypy` → clean
- `pytest tests/` → **69 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)