### PR TITLE
chore: Prepare v0.2.0 release (version bump, citation metadata)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ logs/
 # Documentation builds
 docs/_build/
 docs/build/
+
+# Private research / manuscript working notes (kept local, never published)
+paper/

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,23 @@
+{
+  "title": "jump-diffusion-estimation",
+  "description": "A Python library for simulating and estimating jump-diffusion processes with pluggable asymmetric, heavy-tailed jump-size distributions (skew-normal, Merton normal, SGED, Kou double-exponential, Student-t). It provides maximum-likelihood estimation via L-BFGS-B and Differential Evolution, likelihood-based inference through profile-likelihood, Wald (observed Fisher information) and parametric-bootstrap standard errors and confidence intervals, a parametric-bootstrap test for the presence of jumps, and goodness-of-fit comparison across jump distributions.",
+  "upload_type": "software",
+  "license": "MIT",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Ospina Arango, Juan David"
+    }
+  ],
+  "keywords": [
+    "jump-diffusion",
+    "stochastic-processes",
+    "maximum-likelihood",
+    "differential-evolution",
+    "profile-likelihood",
+    "parametric-bootstrap",
+    "quantitative-finance",
+    "parameter-estimation",
+    "python"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-07-10
+
+### Added
+- **Likelihood-based inference**, three complementary routes on
+  `JumpDiffusionEstimator`:
+  - `estimate_standard_errors()` — profile-likelihood intervals (Wilks).
+  - `estimate_wald_standard_errors()` — Wald intervals from the observed
+    Fisher information (numerical Hessian).
+  - `estimate_bootstrap_standard_errors()` — parametric bootstrap standard
+    errors and percentile intervals.
+- `test_for_jumps()` — a parametric-bootstrap likelihood-ratio test of
+  `H0: jump_prob = 0`, correctly handling the boundary and
+  unidentified-nuisance-parameter pathologies.
+- `summary()` — a tidy table collecting the estimates and every inference
+  route computed, and a public `param_names` property.
+- Canonical end-to-end tutorial notebook, with English and Spanish versions
+  of all notebooks.
+
+### Changed
+- The goodness-of-fit Kolmogorov-Smirnov check in `JumpDistributionComparison`
+  now uses a valid parametric-bootstrap p-value (a large reference sample for
+  a stable statistic, plus re-fitting under the fitted null), replacing the
+  previous single-sample comparison.
+
+### Fixed
+- Restored a green CI baseline by resolving accumulated linting/formatting
+  debt across the package.
+
+## [0.1.0]
+
+### Added
+- Initial release: jump-diffusion simulation and maximum-likelihood
+  estimation with pluggable jump-size distributions (skew-normal, Merton
+  normal, SGED, Kou, Student-t), L-BFGS-B and Differential Evolution
+  optimizers, Monte Carlo validation, and goodness-of-fit distribution
+  comparison.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,32 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "jump-diffusion-estimation"
+abstract: >-
+  A Python library for simulating and estimating jump-diffusion processes
+  with pluggable asymmetric, heavy-tailed jump-size distributions
+  (skew-normal, Merton normal, SGED, Kou double-exponential, Student-t).
+  It provides maximum-likelihood estimation via L-BFGS-B and Differential
+  Evolution, likelihood-based inference through profile-likelihood, Wald
+  (observed Fisher information) and parametric-bootstrap standard errors and
+  confidence intervals, a parametric-bootstrap test for the presence of
+  jumps, and goodness-of-fit comparison across jump distributions.
+authors:
+  - family-names: "Ospina Arango"
+    given-names: "Juan David"
+    email: "jdospina@gmail.com"
+version: "0.2.0"
+date-released: "2026-07-10"
+license: MIT
+repository-code: "https://github.com/jdospina/jump-diffusion-estimation"
+url: "https://github.com/jdospina/jump-diffusion-estimation"
+keywords:
+  - jump-diffusion
+  - stochastic-processes
+  - maximum-likelihood
+  - differential-evolution
+  - profile-likelihood
+  - parametric-bootstrap
+  - quantitative-finance
+  - parameter-estimation
+  - python

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 setup(
     name="jump-diffusion-estimation",
     license="MIT",
-    version="0.1.0",
+    version="0.2.0",
     author="Juan David OSPINA ARANGO",
     author_email="jdospina@gmail.com",
     description="A dream about (someday) a comprehensive library for jump-diffusion parameter estimation",

--- a/src/jump_diffusion/__init__.py
+++ b/src/jump_diffusion/__init__.py
@@ -5,7 +5,7 @@ A comprehensive Python library for simulating and estimating parameters
 of jump-diffusion processes with asymmetric jump distributions.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "Juan David OSPINA ARANGO"
 __email__ = "jdospina@gmail.com"
 


### PR DESCRIPTION
Prepares the **v0.2.0** release — the version that adds likelihood-based inference (profile / Wald / bootstrap), the parametric-bootstrap jump test, `summary()`, and the valid bootstrap KS goodness-of-fit test.

## Changes

- **Version bump** `0.1.0 → 0.2.0` in `setup.py` and `jump_diffusion/__init__.py`.
- **`CITATION.cff`** + **`.zenodo.json`** — citation metadata so the GitHub → Zenodo release archives the software correctly and mints a DOI.
- **`CHANGELOG.md`** — documents 0.2.0 and 0.1.0.
- **`.gitignore`**: ignore `paper/` (private research/manuscript notes kept local, never published).

## Verification (local)

- `black --check` / `flake8` / `mypy` → clean
- `pytest tests/` → **69 passed** (editable install, importing `src/`, `__version__ == "0.2.0"`)

## Next (manual, by the maintainer)

Enabling Zenodo requires authorizing it on your GitHub account, which must be done in the Zenodo UI **before** publishing the release. Steps will follow; then the tag `v0.2.0` + GitHub Release triggers the DOI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)