### PR TITLE
chore: Add ORCID to citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,7 +6,8 @@
   "access_right": "open",
   "creators": [
     {
-      "name": "Ospina Arango, Juan David"
+      "name": "Ospina Arango, Juan David",
+      "orcid": "0000-0002-3547-5247"
     }
   ],
   "keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,6 +15,7 @@ authors:
   - family-names: "Ospina Arango"
     given-names: "Juan David"
     email: "jdospina@gmail.com"
+    orcid: "https://orcid.org/0000-0002-3547-5247"
 version: "0.2.0"
 date-released: "2026-07-10"
 license: MIT


### PR DESCRIPTION
Adds Juan David Ospina Arango's ORCID (`0000-0002-3547-5247`) to `CITATION.cff` and `.zenodo.json`, so the Zenodo DOI record and citation metadata are complete before the v0.2.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)