### PR TITLE
docs: Add Zenodo DOI badge and citation DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,6 +18,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-3547-5247"
 version: "0.2.0"
 date-released: "2026-07-10"
+doi: "10.5281/zenodo.21305522"
 license: MIT
 repository-code: "https://github.com/jdospina/jump-diffusion-estimation"
 url: "https://github.com/jdospina/jump-diffusion-estimation"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jump-Diffusion Parameter Estimation
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21305522.svg)](https://doi.org/10.5281/zenodo.21305522)
+
 A comprehensive Python library for simulating and estimating parameters of jump-diffusion processes with asymmetric jump distributions.
 
 ## 🚀 Features


### PR DESCRIPTION
The v0.2.0 release is now archived on Zenodo. This adds the citable DOI.

- README: **DOI badge** using the **concept DOI** (all versions → always resolves to latest): `10.5281/zenodo.21305522`.
- `CITATION.cff`: `doi` field set to the concept DOI.

For reference, the version-specific DOI for v0.2.0 is `10.5281/zenodo.21305523`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)