### PR TITLE
docs: Add Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+# Install the package (so autodoc can import it and its dependencies) plus
+# the documentation toolchain declared in the "docs" extra.
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ tutorials = [
     "seaborn",
     "plotly",
 ]
+docs = [
+    "sphinx",
+    "sphinx-rtd-theme",
+]
 
 [project.scripts]
 jumpdiff-validate = "jump_diffusion.scripts.validate:main"


### PR DESCRIPTION
Adds `.readthedocs.yaml` (config v2) so the existing Sphinx docs build on **Read the Docs**.

- Ubuntu 22.04 / Python 3.11, builds `docs/conf.py`.
- Installs the package (so `autodoc` can import it and its dependencies) plus a new lean **`docs`** extra (`sphinx`, `sphinx-rtd-theme`) — avoids pulling the heavy `dev` extra on RTD.

Verified locally: `make html` builds successfully (same 3 non-fatal warnings the CI docs job already tolerates).

## Follow-up (manual, maintainer)

Import the repo on https://readthedocs.org (one-time, connect GitHub) to activate builds; RTD will then pick up this config automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)