### PR TITLE
docs: Promote PyPI install and add PyPI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Jump-Diffusion Parameter Estimation
 
+[![PyPI version](https://img.shields.io/pypi/v/jump-diffusion-estimation.svg)](https://pypi.org/project/jump-diffusion-estimation/)
+[![Python versions](https://img.shields.io/pypi/pyversions/jump-diffusion-estimation.svg)](https://pypi.org/project/jump-diffusion-estimation/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21305522.svg)](https://doi.org/10.5281/zenodo.21305522)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A comprehensive Python library for simulating and estimating parameters of jump-diffusion processes with asymmetric jump distributions.
 
@@ -32,15 +35,16 @@ Where:
 ## 🛠️ Installation
 
 ```bash
-# Clone the repository
+# Install from PyPI
+pip install jump-diffusion-estimation
+```
+
+Or install the latest development version from source:
+
+```bash
 git clone https://github.com/jdospina/jump-diffusion-estimation.git
 cd jump-diffusion-estimation
-
-# Install the package
 pip install -e .
-
-# Or install from PyPI (when available)
-pip install jump-diffusion-estimation
 ```
 
 ## 🎯 Quick Start


### PR DESCRIPTION
`jump-diffusion-estimation` **0.2.0 is live on PyPI** — verified end-to-end (`pip install jump-diffusion-estimation` in a clean virtualenv → imports, version `0.2.0`, full API).

- Make `pip install jump-diffusion-estimation` the **primary** install method; keep the source install as the development alternative.
- Add **PyPI version**, **supported Python versions**, and **License** badges next to the existing DOI badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)