### PR TITLE
docs: Install notebooks' package from PyPI instead of GitHub

### DIFF
--- a/notebooks/differential_evolution_showcase.ipynb
+++ b/notebooks/differential_evolution_showcase.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "# Instalación de dependencias necesarias\n",
-    "%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git ipywidgets"
+    "%pip install -q jump-diffusion-estimation ipywidgets"
    ]
   },
   {

--- a/notebooks/differential_evolution_showcase_en.ipynb
+++ b/notebooks/differential_evolution_showcase_en.ipynb
@@ -54,7 +54,7 @@
     }
    ],
    "source": [
-    "%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git ipywidgets"
+    "%pip install -q jump-diffusion-estimation ipywidgets"
    ]
   },
   {

--- a/notebooks/jump_diffusion_playground.ipynb
+++ b/notebooks/jump_diffusion_playground.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "# Instalación de dependencias necesarias\n",
-    "%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git ipywidgets"
+    "%pip install -q jump-diffusion-estimation ipywidgets"
    ]
   },
   {

--- a/notebooks/jump_diffusion_playground_en.ipynb
+++ b/notebooks/jump_diffusion_playground_en.ipynb
@@ -30,7 +30,7 @@
    "outputs": [],
    "source": [
     "# Install required dependencies\n",
-    "%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git ipywidgets"
+    "%pip install -q jump-diffusion-estimation ipywidgets"
    ]
   },
   {

--- a/notebooks/sp500_jump_diffusion_example.ipynb
+++ b/notebooks/sp500_jump_diffusion_example.ipynb
@@ -62,8 +62,8 @@
     }
    ],
    "source": [
-    "# Instalación de la librería jump-diffusion-estimation desde GitHub (última versión)\n",
-    "%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git"
+    "# Instalación de la librería jump-diffusion-estimation desde PyPI\n",
+    "%pip install -q jump-diffusion-estimation"
    ]
   },
   {

--- a/notebooks/sp500_jump_diffusion_example_en.ipynb
+++ b/notebooks/sp500_jump_diffusion_example_en.ipynb
@@ -51,8 +51,8 @@
    },
    "outputs": [],
    "source": [
-    "# Install the jump-diffusion-estimation library from GitHub (latest)\n",
-    "%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git"
+    "# Install the jump-diffusion-estimation library from PyPI\n",
+    "%pip install -q jump-diffusion-estimation"
    ]
   },
   {

--- a/notebooks/tutorial_completo.ipynb
+++ b/notebooks/tutorial_completo.ipynb
@@ -46,7 +46,7 @@
     "if importlib.util.find_spec('jump_diffusion') is None:\n",
     "    subprocess.run(\n",
     "        [sys.executable, '-m', 'pip', 'install', '-q',\n",
-    "         'git+https://github.com/jdospina/jump-diffusion-estimation.git'],\n",
+    "         'jump-diffusion-estimation'],\n",
     "        check=True,\n",
     "    )"
    ]

--- a/notebooks/tutorial_completo_en.ipynb
+++ b/notebooks/tutorial_completo_en.ipynb
@@ -48,7 +48,7 @@
     "if importlib.util.find_spec('jump_diffusion') is None:\n",
     "    subprocess.run(\n",
     "        [sys.executable, '-m', 'pip', 'install', '-q',\n",
-    "         'git+https://github.com/jdospina/jump-diffusion-estimation.git'],\n",
+    "         'jump-diffusion-estimation'],\n",
     "        check=True,\n",
     "    )"
    ]


### PR DESCRIPTION
Now that `jump-diffusion-estimation` is [published on PyPI](https://pypi.org/project/jump-diffusion-estimation/), every notebook's install cell should use it.

## What

Switch the install cell in **all 8 notebooks** (Spanish + English) from

```bash
%pip install -q git+https://github.com/jdospina/jump-diffusion-estimation.git
```

to

```bash
%pip install -q jump-diffusion-estimation
```

(and the equivalent change inside the tutorials' conditional `subprocess` install). Install-cell comments updated to match ("desde PyPI" / "from PyPI").

## Why

- Colab users get the **released, versioned** package instead of whatever `main` happens to contain at run time.
- Faster installs (wheel from PyPI vs. git clone + build).

## Scope

Only the install cells — 13 lines across 8 notebooks; no other cells or outputs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)