### PR TITLE
docs: Cap KS bootstrap cost in S&P 500 notebooks

### DIFF
--- a/notebooks/sp500_jump_diffusion_example.ipynb
+++ b/notebooks/sp500_jump_diffusion_example.ipynb
@@ -644,7 +644,9 @@
    "source": [
     "## 4. Comparando distribuciones de salto\n",
     "\n",
-    "Hasta ahora usamos la distribución skew-normal por defecto. Pero la librería permite conectar distintas distribuciones de salto (`jump_distribution=`) sin cambiar nada más del flujo de estimación. Ajustemos las cinco disponibles a los mismos rendimientos y comparémoslas por AIC/BIC y una prueba de Kolmogorov-Smirnov basada en simulación, usando `JumpDistributionComparison`."
+    "Hasta ahora usamos la distribución skew-normal por defecto. Pero la librería permite conectar distintas distribuciones de salto (`jump_distribution=`) sin cambiar nada más del flujo de estimación. Ajustemos las cinco disponibles a los mismos rendimientos y comparémoslas por AIC/BIC y una prueba de Kolmogorov-Smirnov basada en simulación, usando `JumpDistributionComparison`.\n",
+    "\n",
+    "> ⏱️ **Costo computacional**: el p-valor del KS se calcula por **bootstrap paramétrico** — cada réplica re-ajusta el modelo completo. Con el default (`n_bootstrap=199`) la SGED puede tardar varios minutos por sí sola (7 parámetros y verosimilitud por convolución FFT). Aquí usamos `n_bootstrap=49` para un buen balance costo/precisión."
    ]
   },
   {
@@ -865,11 +867,15 @@
     "from jump_diffusion.validation import JumpDistributionComparison\n",
     "\n",
     "comparison = JumpDistributionComparison(log_returns, dt)\n",
-    "comparison.fit(\"Normal\", NormalJump(), seed=42)\n",
-    "comparison.fit(\"SkewNormal\", SkewNormalJump(), seed=42)\n",
-    "comparison.fit(\"SGED\", SGEDJump(), seed=42)\n",
-    "comparison.fit(\"Kou\", KouJump(), seed=42)\n",
-    "comparison.fit(\"StudentT\", StudentTJump(), seed=42)\n",
+    "# n_bootstrap controla las replicas del bootstrap parametrico del p-valor\n",
+    "# KS (cada una RE-AJUSTA el modelo). El default (199) es para analisis\n",
+    "# riguroso; 49 mantiene un p-valor valido con ~4x menos costo. Usa\n",
+    "# n_bootstrap=0 para omitir el p-valor e iterar al instante.\n",
+    "comparison.fit(\"Normal\", NormalJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"SkewNormal\", SkewNormalJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"SGED\", SGEDJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"Kou\", KouJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"StudentT\", StudentTJump(), seed=42, n_bootstrap=49)\n",
     "\n",
     "comparison.compare()"
    ]
@@ -883,12 +889,12 @@
    "source": [
     "En nuestra corrida de referencia (`^GSPC`, 2015-2024), el ranking por AIC fue:\n",
     "\n",
-    "1. **Student-t** (AIC ≈ -14550) -- la mejor, y la única cuyo p-valor de KS (≈0.79) no rechaza que los rendimientos simulados provienen de la misma distribución que los reales.\n",
-    "2. **Kou** (AIC ≈ -14522), también razonable (p-valor KS ≈ 0.36).\n",
-    "3. **Skew-Normal** y **Normal**, muy por detrás, con p-valores de KS < 0.01 -- la prueba rechaza que capturen bien la distribución real.\n",
-    "4. **SGED** -- ⚠️ en esta corrida el optimizador (`L-BFGS-B`) **no convergió** desde su initial guess por defecto (`convergence: False`). Esto es una limitación conocida del optimizador frente a la verosimilitud de la mezcla SGED (el propio hallazgo aplicado de la tesis, comparando BFGS/L-BFGS-B contra Differential Evolution) -- no necesariamente una limitación de la distribución en sí. Es exactamente la motivación para agregar **Differential Evolution** como método de estimación alternativo (ver el roadmap del proyecto).\n",
+    "1. **Student-t** (AIC ≈ -14550) -- la mejor; su p-valor de KS por bootstrap tampoco rechaza que capture la distribución real.\n",
+    "2. **Kou** (AIC ≈ -14522), también razonable según el KS.\n",
+    "3. **Skew-Normal** y **Normal**, muy por detrás; la prueba KS rechaza que capturen bien la distribución real.\n",
+    "4. **SGED** -- ⚠️ en esta corrida el optimizador (`L-BFGS-B`) **no convergió** desde su initial guess por defecto (`convergence: False`). Es una limitación conocida del optimizador local frente a la verosimilitud de la mezcla SGED (el propio hallazgo aplicado de la tesis) -- no necesariamente de la distribución en sí. Por eso la librería también ofrece **Evolución Diferencial** (`method=\"differential_evolution\"`), mucho más robusta aquí.\n",
     "\n",
-    "Si cambias `TICKER` en la Sección 1 y vuelves a correr el notebook, ¡el ranking bien podría cambiar!"
+    "Los p-valores exactos dependen de `n_bootstrap` (son Monte Carlo); el ranking por AIC/BIC no. Si cambias `TICKER` en la Sección 1 y vuelves a correr el notebook, ¡el ranking bien podría cambiar!"
    ]
   },
   {

--- a/notebooks/sp500_jump_diffusion_example_en.ipynb
+++ b/notebooks/sp500_jump_diffusion_example_en.ipynb
@@ -471,7 +471,9 @@
    "source": [
     "## 4. Comparing jump distributions\n",
     "\n",
-    "So far we used the default skew-normal distribution. But the library lets you plug in different jump distributions (`jump_distribution=`) without changing anything else in the estimation flow. Let's fit the five available ones to the same returns and compare them by AIC/BIC and a parametric-bootstrap Kolmogorov-Smirnov test, using `JumpDistributionComparison`."
+    "So far we used the default skew-normal distribution. But the library lets you plug in different jump distributions (`jump_distribution=`) without changing anything else in the estimation flow. Let's fit the five available ones to the same returns and compare them by AIC/BIC and a parametric-bootstrap Kolmogorov-Smirnov test, using `JumpDistributionComparison`.\n",
+    "\n",
+    "> ⏱️ **Computational cost**: the KS p-value is computed by **parametric bootstrap** — each replicate re-fits the full model. With the default (`n_bootstrap=199`) the SGED alone can take several minutes (7 parameters and an FFT-convolution likelihood). Here we use `n_bootstrap=49` as a good cost/precision balance."
    ]
   },
   {
@@ -497,11 +499,15 @@
     "from jump_diffusion.validation import JumpDistributionComparison\n",
     "\n",
     "comparison = JumpDistributionComparison(log_returns, dt)\n",
-    "comparison.fit(\"Normal\", NormalJump(), seed=42)\n",
-    "comparison.fit(\"SkewNormal\", SkewNormalJump(), seed=42)\n",
-    "comparison.fit(\"SGED\", SGEDJump(), seed=42)\n",
-    "comparison.fit(\"Kou\", KouJump(), seed=42)\n",
-    "comparison.fit(\"StudentT\", StudentTJump(), seed=42)\n",
+    "# n_bootstrap controls the parametric-bootstrap replicates behind the KS\n",
+    "# p-value (each one RE-FITS the model). The default (199) targets\n",
+    "# rigorous analysis; 49 keeps a valid p-value at ~4x less cost. Use\n",
+    "# n_bootstrap=0 to skip the p-value and iterate instantly.\n",
+    "comparison.fit(\"Normal\", NormalJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"SkewNormal\", SkewNormalJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"SGED\", SGEDJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"Kou\", KouJump(), seed=42, n_bootstrap=49)\n",
+    "comparison.fit(\"StudentT\", StudentTJump(), seed=42, n_bootstrap=49)\n",
     "\n",
     "comparison.compare()"
    ]
@@ -514,12 +520,12 @@
    "source": [
     "In our reference run (`^GSPC`, 2015-2024), the AIC ranking was:\n",
     "\n",
-    "1. **Student-t** (AIC ≈ -14550) -- the best, and the only one whose KS p-value (≈0.79) does not reject that the simulated returns come from the same distribution as the real ones.\n",
-    "2. **Kou** (AIC ≈ -14522), also reasonable (KS p-value ≈ 0.36).\n",
-    "3. **Skew-Normal** and **Normal**, well behind, with KS p-values < 0.01 -- the test rejects that they capture the real distribution well.\n",
-    "4. **SGED** -- ⚠️ in this run the optimizer (`L-BFGS-B`) **did not converge** from its default initial guess (`convergence: False`). This is a known limitation of the local optimizer against the SGED mixture likelihood (the thesis's own applied finding, comparing BFGS/L-BFGS-B against Differential Evolution) -- not necessarily a limitation of the distribution itself. It is exactly why the library also provides **Differential Evolution** as an alternative estimation method (`method=\"differential_evolution\"`), which is far more robust here.\n",
+    "1. **Student-t** (AIC ≈ -14550) -- the best; its bootstrap KS p-value also does not reject that it captures the real distribution.\n",
+    "2. **Kou** (AIC ≈ -14522), also reasonable per the KS test.\n",
+    "3. **Skew-Normal** and **Normal**, well behind; the KS test rejects that they capture the real distribution well.\n",
+    "4. **SGED** -- ⚠️ in this run the optimizer (`L-BFGS-B`) **did not converge** from its default initial guess (`convergence: False`). This is a known limitation of the local optimizer against the SGED mixture likelihood (the thesis's own applied finding) -- not necessarily of the distribution itself. That is why the library also provides **Differential Evolution** (`method=\"differential_evolution\"`), far more robust here.\n",
     "\n",
-    "If you change `TICKER` in Section 1 and rerun the notebook, the ranking may well change!"
+    "Exact p-values depend on `n_bootstrap` (they are Monte Carlo); the AIC/BIC ranking does not. If you change `TICKER` in Section 1 and rerun the notebook, the ranking may well change!"
    ]
   },
   {


### PR DESCRIPTION
## Problem

Since #54, `JumpDistributionComparison.fit()` computes the KS p-value by **parametric bootstrap** — each replicate **re-fits the model** (default `n_bootstrap=199`, sized for rigorous analysis). The S&P 500 notebooks still called `fit()` with defaults, so the SGED family alone (7 parameters, FFT-convolution likelihood, ~2.3k observations) ran for many minutes — the reported "SGED optimization takes forever".

**Benchmark** (n=2265, local): 1 SGED fit ≈ 1.3s → default 199 replicates ≈ 4–5 min locally, far worse on Colab; the cell fits five families.

## Fix

Both notebooks (es/en) now pass **`n_bootstrap=49`** explicitly (matching the tutorial notebooks), plus a code comment and a markdown note explaining the cost knob and the `n_bootstrap=0` escape hatch.

**Measured end to end**: `fit("SGED", ..., n_bootstrap=49)` → **72s** locally with a valid Monte Carlo p-value.

## Also

- The results-discussion cell quoted exact KS p-values produced by the **old (invalid, pre-#54) two-sample test**; now stated qualitatively. The AIC ranking (likelihood-based, unaffected) stays.
- The Spanish cell still framed Differential Evolution as a *roadmap item* — corrected (the English sibling was already fixed in #57).

Notebooks only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)