### PR TITLE
chore: Prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-07-13
+
+### Fixed
+- `plot_simulation()` no longer renders twice in Jupyter notebooks: the
+  figure is now deregistered from pyplot before being returned, so it
+  displays exactly once via the returned object. In non-cell contexts
+  (e.g. `ipywidgets.Output`, callbacks), display the returned figure
+  explicitly with `display(fig)`.
+
+### Changed
+- Packaging modernized to `pyproject.toml` (PEP 621) with automated PyPI
+  publishing via trusted publishing; the package is now on PyPI and
+  documentation is hosted on Read the Docs.
+- All notebooks (Spanish and English) install the released package from
+  PyPI instead of GitHub, and the S&P 500 notebooks cap the KS
+  parametric-bootstrap cost with an explicit `n_bootstrap=49`.
+- Citation metadata: Zenodo DOI and author ORCID added; JOSS paper draft
+  included under `paper/`.
+
 ## [0.2.0] - 2026-07-10
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ authors:
     given-names: "Juan David"
     email: "jdospina@gmail.com"
     orcid: "https://orcid.org/0000-0002-3547-5247"
-version: "0.2.0"
-date-released: "2026-07-10"
+version: "0.2.1"
+date-released: "2026-07-13"
 doi: "10.5281/zenodo.21305522"
 license: MIT
 repository-code: "https://github.com/jdospina/jump-diffusion-estimation"

--- a/src/jump_diffusion/__init__.py
+++ b/src/jump_diffusion/__init__.py
@@ -5,7 +5,7 @@ A comprehensive Python library for simulating and estimating parameters
 of jump-diffusion processes with asymmetric jump distributions.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Juan David OSPINA ARANGO"
 __email__ = "jdospina@gmail.com"
 


### PR DESCRIPTION
Patch release prep. The headline is the `plot_simulation()` **duplicate-render fix** (#67): it lives in library code, and since #66 the notebooks install from **PyPI**, so the fix only reaches users once a release is published.

- Version bump `0.2.0 → 0.2.1` (single source: `jump_diffusion.__init__`; `pyproject.toml` reads it dynamically).
- `CHANGELOG.md` entry for 0.2.1: the fix, plus the packaging/dissemination changes since 0.2.0 (pyproject + trusted publishing, PyPI install in notebooks, RTD, citation metadata, JOSS draft).
- `CITATION.cff`: version + release date.

After merge: tag `v0.2.1` + GitHub Release → the publish workflow pushes to PyPI automatically and Zenodo mints the version DOI.

Verification: `black`/`flake8`/`mypy` clean; **70 tests passed**; editable install reports `0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)