### PR TITLE
fix: Keep FFT-convolution grid honest across the parameter space

### DIFF
--- a/src/jump_diffusion/distributions/base.py
+++ b/src/jump_diffusion/distributions/base.py
@@ -56,6 +56,21 @@ class JumpDistribution(ABC):
         """
         return params.get("jump_scale", 1.0)
 
+    def characteristic_location(self, params: Dict[str, float]) -> float:
+        """
+        Rough center of the jump-size distribution, used to place the
+        FFT/inverse-CDF grids in :meth:`fft_convolved_pdf` and :meth:`rvs`
+        so that a shifted distribution (e.g. ``StudentTJump``/``SGEDJump``
+        with a large ``jump_loc``) does not fall outside a grid centered at
+        the origin.
+
+        Default reads ``jump_loc`` (0 when absent). Distributions whose
+        center is not a ``jump_loc`` parameter but stays within a few
+        characteristic scales of zero (e.g. ``KouJump``) are already covered
+        by the grids' tail margins and need no override.
+        """
+        return params.get("jump_loc", 0.0)
+
     def diffusion_convolved_pdf(
         self,
         x: np.ndarray,
@@ -91,16 +106,40 @@ class JumpDistribution(ABC):
         on a symmetric grid of ``2 * 2**j`` half-integer-offset points
         around zero, convolved via FFT, and linearly interpolated to
         evaluate at the requested points.
+
+        Two guards keep the discretization honest across the whole
+        parameter space an optimizer may probe:
+
+        * When ``h`` is not given, the step is chosen for resolution
+          (1/200th of the narrowest density) but then *coarsened* if the
+          resulting span ``2**j * h`` could not contain the densities'
+          mass -- e.g. a jump scale much larger than the diffusion scale,
+          or a jump location far from the origin. A slightly coarser grid
+          that preserves total mass beats a fine grid that silently
+          truncates it.
+        * Points of ``x`` outside the grid evaluate to 0 (the density is
+          genuinely negligible there once the span covers the mass); they
+          no longer zero out the *whole* result, which previously created
+          an artificial likelihood cliff whenever a single extreme
+          observation fell outside the grid of a small-scale candidate.
         """
         x = np.asarray(x, dtype=float)
         jump_std = self.characteristic_scale(params)
         if jump_std is None or jump_std <= 0:
             return np.zeros_like(x)
-
-        if h is None:
-            h = min(diffusion_std, jump_std) / 200.0
+        jump_loc = self.characteristic_location(params)
 
         m = 2**j
+        if h is None:
+            # Step chosen for resolution, then coarsened if the span could
+            # not contain the mass of both densities (plus tail margins).
+            h = min(diffusion_std, jump_std) / 200.0
+            half_span_needed = (
+                abs(diffusion_mean) + abs(jump_loc) + 10.0 * (diffusion_std + jump_std)
+            )
+            if m * h < half_span_needed:
+                h = half_span_needed / m
+
         k = np.arange(-m + 0.5, m, 1.0)  # length 2*m, half-integer offsets
         x_grid = k * h
 
@@ -115,10 +154,7 @@ class JumpDistribution(ABC):
         conv = np.concatenate([conv[m:], conv[:m]])  # re-center around x_grid
         conv = np.maximum(conv, 0.0)
 
-        if x.min() < x_grid[0] or x.max() > x_grid[-1]:
-            return np.zeros_like(x)
-
-        return np.interp(x, x_grid, conv)
+        return np.interp(x, x_grid, conv, left=0.0, right=0.0)
 
     def rvs(
         self,
@@ -143,7 +179,9 @@ class JumpDistribution(ABC):
         h = jump_std / 200.0
         m = 2**12  # a coarser grid than fft_convolved_pdf suffices here
         k = np.arange(-m + 0.5, m, 1.0)
-        x_grid = k * h
+        # Centered on the distribution's location so that a shifted
+        # distribution (large jump_loc) is not sampled from an empty grid.
+        x_grid = self.characteristic_location(params) + k * h
         density = np.maximum(self.pdf(x_grid, params), 0.0)
         cdf = np.cumsum(density) * h
         cdf /= cdf[-1]

--- a/src/jump_diffusion/distributions/base.py
+++ b/src/jump_diffusion/distributions/base.py
@@ -130,18 +130,20 @@ class JumpDistribution(ABC):
         jump_loc = self.characteristic_location(params)
 
         m = 2**j
-        if h is None:
+        if h is not None:
+            step = h
+        else:
             # Step chosen for resolution, then coarsened if the span could
             # not contain the mass of both densities (plus tail margins).
-            h = min(diffusion_std, jump_std) / 200.0
+            step = min(diffusion_std, jump_std) / 200.0
             half_span_needed = (
                 abs(diffusion_mean) + abs(jump_loc) + 10.0 * (diffusion_std + jump_std)
             )
-            if m * h < half_span_needed:
-                h = half_span_needed / m
+            if m * step < half_span_needed:
+                step = half_span_needed / m
 
         k = np.arange(-m + 0.5, m, 1.0)  # length 2*m, half-integer offsets
-        x_grid = k * h
+        x_grid = k * step
 
         f_diffusion = norm.pdf(x_grid, loc=diffusion_mean, scale=diffusion_std)
         f_jump = self.pdf(x_grid, params)
@@ -150,7 +152,7 @@ class JumpDistribution(ABC):
 
         # numpy's ifft already divides by n, unlike R's fft(..., inverse=TRUE)
         conv = np.real(np.fft.ifft(np.fft.fft(f_diffusion) * np.fft.fft(f_jump)))
-        conv *= h
+        conv *= step
         conv = np.concatenate([conv[m:], conv[:m]])  # re-center around x_grid
         conv = np.maximum(conv, 0.0)
 

--- a/tests/test_distributions/test_fft_convolution.py
+++ b/tests/test_distributions/test_fft_convolution.py
@@ -1,0 +1,81 @@
+"""Regression tests for the FFT-convolution grid (audit findings B1/B2).
+
+The generic ``fft_convolved_pdf`` previously (a) returned an all-zero
+density whenever ANY requested point fell outside its grid -- creating an
+artificial likelihood cliff for small-scale candidates on data with
+extreme observations -- and (b) sized/centered its grid ignoring both a
+dominant jump scale and a shifted jump location, silently losing the
+distribution's mass.
+"""
+
+import numpy as np
+from scipy.integrate import simpson
+
+from jump_diffusion.distributions import NormalJump, SGEDJump, StudentTJump
+
+DM, DS = 0.0002, 0.0126  # typical daily drift/vol of the diffusion part
+
+
+class TestGridCoverage:
+    def test_outlier_does_not_zero_whole_density(self):
+        # Small-scale candidate + one extreme observation beyond the grid:
+        # in-grid points must keep their density; only the outlier is ~0.
+        dist = StudentTJump()
+        params = {"jump_loc": 0.0, "jump_scale": 0.001, "jump_df": 5.0}
+        xs = np.array([0.0, 0.01, 0.3])  # 0.3 lies beyond the small grid
+
+        dens = dist.fft_convolved_pdf(xs, params, DM, DS)
+
+        assert dens[0] > 1.0  # density near the mode is order 1/DS
+        assert dens[1] > 0.0
+        assert dens[2] == 0.0  # genuinely negligible there
+
+    def test_mass_preserved_when_jump_scale_dominates(self):
+        # jump_scale / diffusion_std ~ 160: the old grid (sized by the
+        # *smaller* scale) could not contain the jump's mass at all.
+        dist = StudentTJump()
+        params = {"jump_loc": 0.0, "jump_scale": 0.5, "jump_df": 5.0}
+        grid = np.linspace(-8, 8, 400001)
+
+        mass = simpson(dist.fft_convolved_pdf(grid, params, 0.0, 0.00315), x=grid)
+
+        assert abs(mass - 1.0) < 1e-2
+
+    def test_mass_preserved_with_far_location(self):
+        # jump_loc far from the origin: the grid must still cover the mass.
+        dist = StudentTJump()
+        params = {"jump_loc": 3.0, "jump_scale": 0.02, "jump_df": 5.0}
+        grid = np.linspace(2.0, 4.0, 200001)
+
+        mass = simpson(dist.fft_convolved_pdf(grid, params, DM, DS), x=grid)
+
+        assert abs(mass - 1.0) < 1e-2
+
+    def test_fft_matches_closed_form_in_normal_regime(self):
+        # Accuracy guard: in the well-covered regime the (unchanged) grid
+        # must keep matching the closed form.
+        dist = NormalJump()
+        params = {"jump_scale": 0.1}
+        xs = np.linspace(-0.4, 0.4, 41)
+
+        fft_dens = dist.fft_convolved_pdf(xs, params, DM, DS)
+        closed = dist.diffusion_convolved_pdf(xs, params, DM, DS)
+
+        np.testing.assert_allclose(fft_dens, closed, rtol=5e-3, atol=1e-6)
+
+
+class TestGenericRvsLocation:
+    def test_generic_rvs_respects_location(self):
+        # SGED uses the generic inverse-CDF sampler; a shifted location
+        # must shift the sample, not fall off a zero-centered grid.
+        dist = SGEDJump()
+        params = {
+            "jump_loc": 0.5,
+            "jump_scale": 0.05,
+            "jump_nu": 1.5,
+            "jump_xi": 1.2,
+        }
+        sample = dist.rvs(params, size=20000, random_state=np.random.default_rng(0))
+
+        assert abs(np.mean(sample) - 0.5) < 0.01
+        assert abs(np.std(sample) - 0.05) < 0.01


### PR DESCRIPTION
Fixes audit findings **B1** and **B2** (the two real bugs from the systematic diagnostic), with regression tests derived from the audit battery.

## B1 — one out-of-grid point zeroed the WHOLE density

`fft_convolved_pdf` returned all-zeros if **any** requested point fell outside its grid. With one extreme observation in the data (e.g. |log-return| ≈ 0.11 in the S&P 500), every candidate with `jump_scale < max|x|/163.8` (≈ 7e-4 there, while the bound allows 1e-6) produced an artificially flat, floored likelihood — a **cliff** that biases against small scales, breaks the smoothness L-BFGS-B relies on (plausible contributor to the SGED non-convergence on real data), and would contaminate exactly the `p→0` / `scale→0` boundary region the research study targets.

**Fix**: out-of-grid points now evaluate to 0 *individually* (`np.interp(..., left=0, right=0)`). Correct, because once the span covers the mass, the density out there is genuinely negligible — and the mixture's diffusion component (computed in closed form) still handles those observations.

## B2 — grid sized by the smaller scale and centered at the origin

Measured: jump scale dominating the diffusion scale (ratio ~160) → integrated mass **0.0**; `jump_loc = 3` → mass entirely lost.

**Fix**: the step is still chosen for resolution (1/200 of the narrowest density) but is now **coarsened** when the span `2**j · h` cannot contain `|diffusion_mean| + |location| + 10·(sum of scales)`. A slightly coarser grid that preserves total mass beats a fine grid that silently truncates it. **The default regime (scale ratios up to ~18) is bit-for-bit unchanged.**

Also adds `JumpDistribution.characteristic_location` (reads `jump_loc`, 0 when absent) and centers the generic inverse-CDF sampler's grid on it, so shifted distributions sample correctly too.

## Verification

Audit checks before → after:

| Check | before | after |
|---|---|---|
| Outlier + small-scale candidate, density at mode | 0.0 | 31.56 |
| Mass at scale ratio ~160 | 0.0000 | 1.0000 |
| Mass with `jump_loc=3` | 0.0000 | 1.0000 |
| FFT vs closed form, normal regime | ≤2e-3 | unchanged |

5 new regression tests; full suite **75 passed**; `black`/`flake8`/`mypy` clean; the full audit battery (pdf normalization, rvs vs pdf, closed forms vs quadrature, mixture normalization) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)