### PR TITLE
fix: Include jump contribution in diagnostics() theoretical moments

### DIFF
--- a/src/jump_diffusion/distributions/base.py
+++ b/src/jump_diffusion/distributions/base.py
@@ -158,6 +158,56 @@ class JumpDistribution(ABC):
 
         return np.interp(x, x_grid, conv, left=0.0, right=0.0)
 
+    def _moment_grid(
+        self, params: Dict[str, float]
+    ) -> Tuple[np.ndarray, np.ndarray, float]:
+        """
+        Shared discretization of ``pdf`` used by :meth:`rvs`, :meth:`mean`
+        and :meth:`variance`: ``2**13`` points spanning ~20 characteristic
+        scales around the characteristic location.
+
+        Returns ``(x_grid, density, step)``.
+        """
+        jump_std = self.characteristic_scale(params)
+        h = jump_std / 200.0
+        m = 2**12  # a coarser grid than fft_convolved_pdf suffices here
+        k = np.arange(-m + 0.5, m, 1.0)
+        # Centered on the distribution's location so that a shifted
+        # distribution (large jump_loc) does not fall off the grid.
+        x_grid = self.characteristic_location(params) + k * h
+        density = np.maximum(self.pdf(x_grid, params), 0.0)
+        return x_grid, density, h
+
+    def mean(self, params: Dict[str, float]) -> float:
+        """
+        Mean jump size ``E[J]``, evaluated numerically on the sampling grid
+        (see :meth:`_moment_grid`). Accurate to the grid's truncation
+        (~20 characteristic scales), which is ample for reporting purposes;
+        heavy-tailed distributions lose a small tail contribution.
+
+        Returns ``nan`` if the density has no mass on the grid.
+        """
+        x_grid, density, h = self._moment_grid(params)
+        total = float(np.sum(density) * h)
+        if total <= 0:
+            return float("nan")
+        return float(np.sum(x_grid * density) * h / total)
+
+    def variance(self, params: Dict[str, float]) -> float:
+        """
+        Jump-size variance ``Var[J]``, evaluated numerically on the sampling
+        grid (see :meth:`_moment_grid`, same truncation caveat as
+        :meth:`mean`).
+
+        Returns ``nan`` if the density has no mass on the grid.
+        """
+        x_grid, density, h = self._moment_grid(params)
+        total = float(np.sum(density) * h)
+        if total <= 0:
+            return float("nan")
+        mean = np.sum(x_grid * density) * h / total
+        return float(np.sum((x_grid - mean) ** 2 * density) * h / total)
+
     def rvs(
         self,
         params: Dict[str, float],
@@ -177,14 +227,7 @@ class JumpDistribution(ABC):
         -- so that simulations stay reproducible. Pass an explicit
         ``np.random.Generator`` for an isolated, independent stream.
         """
-        jump_std = self.characteristic_scale(params)
-        h = jump_std / 200.0
-        m = 2**12  # a coarser grid than fft_convolved_pdf suffices here
-        k = np.arange(-m + 0.5, m, 1.0)
-        # Centered on the distribution's location so that a shifted
-        # distribution (large jump_loc) is not sampled from an empty grid.
-        x_grid = self.characteristic_location(params) + k * h
-        density = np.maximum(self.pdf(x_grid, params), 0.0)
+        x_grid, density, h = self._moment_grid(params)
         cdf = np.cumsum(density) * h
         cdf /= cdf[-1]
         rand = random_state if random_state is not None else np.random

--- a/src/jump_diffusion/estimation/maximum_likelihood.py
+++ b/src/jump_diffusion/estimation/maximum_likelihood.py
@@ -1219,15 +1219,22 @@ class JumpDiffusionEstimator(BaseEstimator):
         # Model comparison with data
         print("\nDATA vs MODEL COMPARISON")
         print("-" * 30)
-        theoretical_mean = params["mu"] * self.dt
-        # Approximation: treats the distribution's characteristic scale as
-        # the jump size's standard deviation, which holds exactly for the
-        # Normal jump distribution and approximately for the others.
-        jump_scale = self._model.jump_distribution.characteristic_scale(
-            {k: params[k] for k in self._model.jump_distribution.param_names}
-        )
+        # Exact moments of the model's Bernoulli-mixture increment
+        # dX = mu*dt + sigma*sqrt(dt)*Z + B*J with B ~ Bernoulli(p):
+        #   E[dX]   = mu*dt + p*E[J]
+        #   Var[dX] = sigma^2*dt + p*E[J^2] - (p*E[J])^2
+        # E[J] and Var[J] come from the jump distribution itself, so the
+        # jump contribution to the mean (crucial for asymmetric jumps) is
+        # no longer ignored.
+        jump_params = {k: params[k] for k in self._model.jump_distribution.param_names}
+        p = params["jump_prob"]
+        jump_mean = self._model.jump_distribution.mean(jump_params)
+        jump_var = self._model.jump_distribution.variance(jump_params)
+        theoretical_mean = params["mu"] * self.dt + p * jump_mean
         theoretical_var = (
-            params["sigma"] ** 2 * self.dt + params["jump_prob"] * jump_scale**2
+            params["sigma"] ** 2 * self.dt
+            + p * (jump_var + jump_mean**2)
+            - (p * jump_mean) ** 2
         )
 
         print("Mean increment:")

--- a/tests/test_distributions/test_moments.py
+++ b/tests/test_distributions/test_moments.py
@@ -1,0 +1,44 @@
+"""Tests for the generic numerical jump-size moments (audit finding B3)."""
+
+import numpy as np
+
+from jump_diffusion.distributions import (
+    KouJump,
+    NormalJump,
+    SkewNormalJump,
+    StudentTJump,
+)
+
+
+class TestMomentsAgainstClosedForms:
+    def test_normal_moments(self):
+        d, p = NormalJump(), {"jump_scale": 0.15}
+        assert abs(d.mean(p)) < 1e-6
+        assert abs(d.variance(p) - 0.15**2) < 1e-6
+
+    def test_skew_normal_moments(self):
+        omega, alpha = 0.15, 3.0
+        d = SkewNormalJump()
+        p = {"jump_scale": omega, "jump_skew": alpha}
+        delta = alpha / np.sqrt(1 + alpha**2)
+        mean_cf = omega * delta * np.sqrt(2 / np.pi)
+        var_cf = omega**2 * (1 - 2 * delta**2 / np.pi)
+        assert abs(d.mean(p) - mean_cf) < 1e-5
+        assert abs(d.variance(p) - var_cf) < 1e-6
+
+    def test_kou_moments(self):
+        pu, su, sd = 0.4, 0.08, 0.12
+        d = KouJump()
+        p = {"jump_prob_up": pu, "jump_scale_up": su, "jump_scale_down": sd}
+        mean_cf = pu * su - (1 - pu) * sd
+        second_cf = pu * 2 * su**2 + (1 - pu) * 2 * sd**2
+        assert abs(d.mean(p) - mean_cf) < 1e-4
+        assert abs(d.variance(p) - (second_cf - mean_cf**2)) < 1e-4
+
+    def test_student_t_moments_with_location(self):
+        d = StudentTJump()
+        p = {"jump_loc": 0.3, "jump_scale": 0.1, "jump_df": 8.0}
+        # Standardized parameterization: mean = loc, std = jump_scale
+        # (up to the grid's ~20-scale tail truncation).
+        assert abs(d.mean(p) - 0.3) < 1e-3
+        assert abs(d.variance(p) - 0.1**2) < 5e-4

--- a/tests/test_estimation/test_diagnostics_moments.py
+++ b/tests/test_estimation/test_diagnostics_moments.py
@@ -1,0 +1,57 @@
+"""Regression test: diagnostics() must include the jump contribution in
+the theoretical mean (audit finding B3)."""
+
+import contextlib
+import io
+
+import numpy as np
+from jump_diffusion.distributions import SkewNormalJump
+from jump_diffusion.estimation import JumpDiffusionEstimator
+from jump_diffusion.simulation import JumpDiffusionSimulator
+
+
+def _parse_theoretical(output: str, section: str) -> float:
+    lines = output.splitlines()
+    start = next(i for i, ln in enumerate(lines) if ln.startswith(section))
+    theo_line = next(ln for ln in lines[start:] if ln.strip().startswith("Theoretical"))
+    return float(theo_line.split(":")[1])
+
+
+def test_theoretical_mean_includes_jump_contribution():
+    # Strongly skewed jumps: E[J] > 0, so mu*dt alone is badly off.
+    sim = JumpDiffusionSimulator(
+        mu=0.05,
+        sigma=0.2,
+        jump_prob=0.1,
+        jump_distribution=SkewNormalJump(),
+        jump_scale=0.15,
+        jump_skew=3.0,
+    )
+    times, path, _ = sim.simulate_path(T=2000 / 252, n_steps=2000, x0=0.0, seed=3)
+    increments = np.diff(path)
+    dt = times[1] - times[0]
+
+    estimator = JumpDiffusionEstimator(
+        increments, dt, jump_distribution=SkewNormalJump()
+    )
+    result = estimator.estimate()
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        estimator.diagnostics()
+    printed = _parse_theoretical(buffer.getvalue(), "Mean increment:")
+
+    params = result["parameters"]
+    jump_params = {
+        name: params[name] for name in estimator._model.jump_distribution.param_names
+    }
+    expected = params["mu"] * dt + params["jump_prob"] * SkewNormalJump().mean(
+        jump_params
+    )
+
+    # Self-consistency with the model's exact mixture mean (print precision).
+    assert abs(printed - expected) < 1e-6
+    # And the jump term must actually matter: mu*dt alone is far away.
+    assert abs(printed - params["mu"] * dt) > 5 * abs(params["mu"] * dt)
+    # Sanity: the fitted model's mean tracks the empirical one.
+    assert abs(printed - np.mean(increments)) < 0.005


### PR DESCRIPTION
Fixes audit finding **B3**.

## Problem

`diagnostics()` printed `mu*dt` as the "theoretical" mean increment, ignoring the jump contribution `p·E[J]`. With asymmetric jumps this misreports the model badly — measured on a skew-normal fit:

| | value |
|---|---|
| printed "Theoretical" mean | **-0.000019** |
| model's actual mean (`μ·dt + p·E[J]`) | **0.011778** |
| empirical mean | 0.011798 |

i.e. the diagnostic suggested a huge data/model mismatch that does not exist (visible in the S&P 500 notebook output). The variance similarly used `characteristic_scale²` as a rough proxy for `E[J²]`.

## Fix

Both moments now come from the model itself:

- `E[ΔX] = μ·dt + p·E[J]`
- `Var[ΔX] = σ²·dt + p·E[J²] − (p·E[J])²`

with new **generic numerical `JumpDistribution.mean()` / `.variance()`**, evaluated on the (now factored-out) `_moment_grid` shared with the inverse-CDF sampler — centered on `characteristic_location`, ~20 characteristic scales of span.

## Verification

Moments checked against closed forms: Normal, skew-normal (Azzalini moments), Kou double-exponential, located Student-t — all within 1e-4 or better. Plus a diagnostics regression test that parses the printed value and asserts self-consistency, that the jump term materially matters, and agreement with the empirical mean.

Full suite **80 passed**; `black`/`flake8`/`mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)