### PR TITLE
fix: Make ValidationExperiment safe for zero-valued true parameters

### DIFF
--- a/src/jump_diffusion/validation/monte_carlo.py
+++ b/src/jump_diffusion/validation/monte_carlo.py
@@ -115,13 +115,17 @@ class ValidationExperiment:
 
                     # Add estimated parameters
                     for param, value in est_results["parameters"].items():
+                        true_val = self.true_params[param]
                         row[f"{param}_est"] = value
-                        row[f"{param}_true"] = self.true_params[param]
-                        row[f"{param}_error"] = value - self.true_params[param]
+                        row[f"{param}_true"] = true_val
+                        row[f"{param}_error"] = value - true_val
+                        # Relative error is undefined when the true value
+                        # is (numerically) zero -- e.g. jump_skew=0 or
+                        # jump_loc=0 -- so report NaN instead of +/-inf.
                         row[f"{param}_rel_error"] = (
-                            (value - self.true_params[param])
-                            / self.true_params[param]
-                            * 100
+                            (value - true_val) / true_val * 100
+                            if abs(true_val) > 1e-12
+                            else np.nan
                         )
 
                     results.append(row)
@@ -161,10 +165,19 @@ class ValidationExperiment:
         """
         Analyze validation results and compute statistics.
 
+        Note that all statistics condition on the runs that converged
+        (non-converged runs are dropped by :meth:`run_experiment`), so with
+        a low convergence rate they carry selection bias. Relative-error
+        statistics are ``nan`` for parameters whose true value is zero.
+
         Returns:
         --------
         dict
-            Analysis results including bias, RMSE, etc.
+            Per-parameter statistics: bias, RMSE, MAE, relative errors and
+            ``within_5pct_rate`` -- the share of converged runs whose
+            estimate lies within 5% (relative) of the true value. (This
+            was previously misnamed ``coverage_95``; it is an accuracy
+            rate, not confidence-interval coverage.)
         """
         if len(self.results) == 0:
             print("No results to analyze. Run experiment first.")
@@ -181,7 +194,8 @@ class ValidationExperiment:
             true_val = self.true_params[param]
             estimated_vals = self.results[f"{param}_est"]
             errors = self.results[f"{param}_error"]
-            rel_errors = self.results[f"{param}_rel_error"]
+            rel_errors = self.results[f"{param}_rel_error"].to_numpy()
+            finite_rel = rel_errors[np.isfinite(rel_errors)]
 
             stats = {
                 "true_value": true_val,
@@ -189,11 +203,15 @@ class ValidationExperiment:
                 "bias": np.mean(errors),
                 "rmse": np.sqrt(np.mean(errors**2)),
                 "mae": np.mean(np.abs(errors)),
-                "mean_rel_error": np.mean(rel_errors),
+                "mean_rel_error": (
+                    float(np.mean(finite_rel)) if len(finite_rel) else float("nan")
+                ),
                 "std_estimate": np.std(estimated_vals),
-                "coverage_95": np.mean(
-                    np.abs(rel_errors) <= 5
-                ),  # Within 5% of true value
+                "within_5pct_rate": (
+                    float(np.mean(np.abs(finite_rel) <= 5))
+                    if len(finite_rel)
+                    else float("nan")
+                ),
             }
 
             analysis[param] = stats
@@ -204,7 +222,7 @@ class ValidationExperiment:
             print(f"  RMSE:            {stats['rmse']:.6f}")
             print(f"  Mean rel. error: {stats['mean_rel_error']:.2f}%")
             print(f"  Std deviation:   {stats['std_estimate']:.6f}")
-            print(f"  95% accuracy:    {stats['coverage_95']:.1%}")
+            print(f"  Within 5% of truth: {stats['within_5pct_rate']:.1%}")
 
         return analysis
 
@@ -279,21 +297,23 @@ class ValidationExperiment:
                 label="Perfect Estimation",
             )
 
-            # Confidence bands (±10% and ±20%)
-            ax.axhspan(
-                true_val * 0.9,
-                true_val * 1.1,
-                alpha=0.2,
-                color="green",
-                label="±10% band",
-            )
-            ax.axhspan(
-                true_val * 0.8,
-                true_val * 1.2,
-                alpha=0.1,
-                color="yellow",
-                label="±20% band",
-            )
+            # Relative accuracy bands (±10% and ±20%); meaningless (zero
+            # width) when the true value is zero, so skip them there.
+            if abs(true_val) > 1e-12:
+                ax.axhspan(
+                    true_val * 0.9,
+                    true_val * 1.1,
+                    alpha=0.2,
+                    color="green",
+                    label="±10% band",
+                )
+                ax.axhspan(
+                    true_val * 0.8,
+                    true_val * 1.2,
+                    alpha=0.1,
+                    color="yellow",
+                    label="±20% band",
+                )
 
             ax.set_xlabel("True Value")
             ax.set_ylabel("Estimated Value")
@@ -303,17 +323,23 @@ class ValidationExperiment:
             if i == 0:  # Add legend to first plot
                 ax.legend()
 
-        # Summary statistics plot
+        # Summary statistics plot. Relative measures are undefined (NaN)
+        # for parameters whose true value is zero; matplotlib simply skips
+        # those bars.
         ax = axes[len(param_names)]
         param_biases = []
+        param_rmses = []
         for param in param_names:
-            param_biases.append(np.mean(self.results[f"{param}_rel_error"]))
-        param_rmses = [
-            np.sqrt(np.mean(self.results[f"{param}_error"] ** 2))
-            / self.true_params[param]
-            * 100
-            for param in param_names
-        ]
+            rel = self.results[f"{param}_rel_error"].to_numpy()
+            finite_rel = rel[np.isfinite(rel)]
+            param_biases.append(
+                float(np.mean(finite_rel)) if len(finite_rel) else float("nan")
+            )
+            true_val = self.true_params[param]
+            rmse = np.sqrt(np.mean(self.results[f"{param}_error"] ** 2))
+            param_rmses.append(
+                rmse / abs(true_val) * 100 if abs(true_val) > 1e-12 else float("nan")
+            )
 
         x = np.arange(len(param_names))
         width = 0.35

--- a/tests/test_validation/test_rel_error_zero_truth.py
+++ b/tests/test_validation/test_rel_error_zero_truth.py
@@ -1,0 +1,56 @@
+"""Regression tests: ValidationExperiment with a zero true parameter
+(audit finding B4) must not produce infinite relative errors."""
+
+import contextlib
+import io
+
+import numpy as np
+
+from jump_diffusion.distributions import SkewNormalJump
+from jump_diffusion.validation import ValidationExperiment
+
+TRUE_PARAMS = {
+    "mu": 0.05,
+    "sigma": 0.2,
+    "jump_prob": 0.2,
+    "jump_scale": 0.1,
+    "jump_skew": 0.0,  # true value exactly zero
+}
+
+
+def _run_experiment():
+    experiment = ValidationExperiment(TRUE_PARAMS, jump_distribution=SkewNormalJump())
+    with contextlib.redirect_stdout(io.StringIO()):
+        results = experiment.run_experiment(n_simulations=3, n_steps=300, seed_base=1)
+    return experiment, results
+
+
+def test_zero_truth_yields_nan_not_inf():
+    _, results = _run_experiment()
+    assert len(results) > 0
+
+    rel = results["jump_skew_rel_error"].to_numpy()
+    assert not np.any(np.isinf(rel))
+    assert np.all(np.isnan(rel))
+
+    # Non-zero parameters keep finite relative errors.
+    assert np.all(np.isfinite(results["sigma_rel_error"]))
+
+
+def test_analysis_is_inf_free_and_reports_accuracy_rate():
+    experiment, _ = _run_experiment()
+    with contextlib.redirect_stdout(io.StringIO()):
+        analysis = experiment.analyze_results()
+
+    skew_stats = analysis["jump_skew"]
+    # Relative measures are undefined for a zero truth: nan, never inf.
+    assert np.isnan(skew_stats["mean_rel_error"])
+    assert np.isnan(skew_stats["within_5pct_rate"])
+    # Absolute measures remain finite.
+    assert np.isfinite(skew_stats["bias"])
+    assert np.isfinite(skew_stats["rmse"])
+
+    # The honestly-named accuracy rate replaces the old "coverage_95".
+    assert "coverage_95" not in skew_stats
+    sigma_stats = analysis["sigma"]
+    assert 0.0 <= sigma_stats["within_5pct_rate"] <= 1.0


### PR DESCRIPTION
Fixes audit finding **B4** (last of the four).

## Problem

With a true parameter equal to zero — `jump_skew=0`, `jump_loc=0` or `mu=0`, all natural experiment settings — the relative error divided by zero and produced **±inf**, contaminating the results DataFrame, the analysis summary and the plots. Confirmed in the audit: `jump_skew_rel_error = [-inf, inf]`.

## Fix

- **`run_experiment`**: relative error is `NaN` when `|true| ≤ 1e-12` (undefined, not infinite); absolute error/bias/RMSE unaffected.
- **`analyze_results`**: relative statistics computed over finite values only (`NaN` when none exist). **`coverage_95` renamed to `within_5pct_rate`** and its printout to *"Within 5% of truth"* — it is an accuracy rate, not confidence-interval coverage, and the old name became actively confusing now that the estimator ships real CI machinery (profile/Wald/bootstrap). Docstring also notes that statistics condition on converged runs.
- **`plot_results`**: accuracy bands skipped for zero-valued true parameters (they had zero width); summary bars NaN-safe.

> Note: `within_5pct_rate` is a small breaking rename in the validation utility's analysis dict; flagged for the next release's changelog.

## Tests

2 regression tests reproducing the audit scenario (skew-normal fit with true `jump_skew = 0`): NaN-not-inf in results, inf-free analysis, old key gone, sane rate for well-defined parameters.

Full suite **82 passed**; `black`/`flake8`/`mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)