### PR TITLE
chore: Prepare v0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-07-14
+
+Fixes from a systematic audit of the library (line-by-line code review
+plus a numerical battery verifying mathematical invariants).
+
+### Fixed
+- FFT-convolution density (`fft_convolved_pdf`), used by the SGED and
+  Student-t families:
+  - A single evaluation point outside the grid no longer zeroes the
+    *whole* returned density (previously an artificial likelihood cliff
+    for small-scale candidates whenever the data contained an extreme
+    observation). Out-of-grid points now evaluate to 0 individually.
+  - The grid step is coarsened when the default span cannot contain the
+    densities' mass (dominant jump scale, or a jump location far from
+    the origin), preserving total mass instead of silently truncating
+    it. The default regime is unchanged.
+- `diagnostics()` theoretical moments now include the jump contribution
+  (`E[dX] = mu*dt + p*E[J]`; exact mixture variance). Previously the
+  mean ignored jumps entirely, badly misreporting models with
+  asymmetric jumps.
+- `ValidationExperiment` no longer produces infinite relative errors
+  when a true parameter is zero (now `NaN`), and its plots/summaries
+  are NaN-safe.
+
+### Added
+- `JumpDistribution.mean()` / `.variance()`: generic numerical jump-size
+  moments, verified against closed forms.
+- `JumpDistribution.characteristic_location()`: grid placement for
+  shifted jump distributions; the generic sampler now centers on it.
+
+### Changed
+- `ValidationExperiment.analyze_results()`: the misnamed `coverage_95`
+  statistic is now `within_5pct_rate` (it is an accuracy rate, not
+  confidence-interval coverage).
+- English is now the repository's primary language: README fully in
+  English, and notebooks renamed — English names unsuffixed
+  (`getting_started`, `jump_diffusion_playground`,
+  `differential_evolution_showcase`, `sp500_case_study`) with Spanish
+  versions carrying the `_spanish` suffix. Links to the old notebook
+  filenames no longer work.
+
 ## [0.2.1] - 2026-07-13
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ authors:
     given-names: "Juan David"
     email: "jdospina@gmail.com"
     orcid: "https://orcid.org/0000-0002-3547-5247"
-version: "0.2.1"
-date-released: "2026-07-13"
+version: "0.2.2"
+date-released: "2026-07-14"
 doi: "10.5281/zenodo.21305522"
 license: MIT
 repository-code: "https://github.com/jdospina/jump-diffusion-estimation"

--- a/src/jump_diffusion/__init__.py
+++ b/src/jump_diffusion/__init__.py
@@ -5,7 +5,7 @@ A comprehensive Python library for simulating and estimating parameters
 of jump-diffusion processes with asymmetric jump distributions.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "Juan David OSPINA ARANGO"
 __email__ = "jdospina@gmail.com"
 


### PR DESCRIPTION
Patch-release prep. Carries the **four audit fixes** (#70–#72) — they live in library code, so they only reach PyPI/Colab users once released — plus the English-first README and notebook renames (#73, #74).

- Version bump `0.2.1 → 0.2.2` (single source: `jump_diffusion.__init__`).
- `CHANGELOG.md` entry for 0.2.2: FFT-grid fixes, diagnostics moments, ValidationExperiment zero-truth fix, **`coverage_95 → within_5pct_rate` rename**, new `mean()`/`variance()`/`characteristic_location()` APIs, notebook renames (old links 404).
- `CITATION.cff`: version + release date.

After merge: tag `v0.2.2` + GitHub Release → auto-publish to PyPI; Zenodo mints the version DOI.

Verification: `black`/`flake8`/`mypy` clean; **82 tests passed**; editable install reports `0.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)